### PR TITLE
Fix: add type information for jersey client deserialization

### DIFF
--- a/src/main/java/in/zapr/druid/druidry/client/DruidJerseyClient.java
+++ b/src/main/java/in/zapr/druid/druidry/client/DruidJerseyClient.java
@@ -1,5 +1,6 @@
 package in.zapr.druid.druidry.client;
 
+import org.apache.commons.lang3.reflect.TypeUtils;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.glassfish.jersey.apache.connector.ApacheClientProperties;
@@ -112,7 +113,7 @@ public class DruidJerseyClient implements DruidClient {
                 handleInternalServerResponse(response);
             }
 
-            return response.readEntity(new GenericType<List<T>>() {
+            return response.readEntity(new GenericType<List<T>>(TypeUtils.parameterize(List.class, className)) {
             });
         } catch (QueryException e) {
             log.error("Exception while querying {}", e);


### PR DESCRIPTION
This bug causes all the druid response to be deserialized as `LinkedHashMap` , and consequently causes `ClassCastException` at runtime.