### PR TITLE
Add field to ThetaSketch post aggregation. Allow dimensions to be null

### DIFF
--- a/src/main/java/in/zapr/druid/druidry/extensions/datasketches/postAggregator/ThetaSketchEstimatePostAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/extensions/datasketches/postAggregator/ThetaSketchEstimatePostAggregator.java
@@ -18,29 +18,23 @@ package in.zapr.druid.druidry.extensions.datasketches.postAggregator;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import in.zapr.druid.druidry.postAggregator.DruidPostAggregator;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ThetaSketchEstimatePostAggregator extends DruidPostAggregator {
 
     private static final String THETA_SKETCH_ESTIMATE_POST_AGGREGATOR_TYPE = "thetaSketchEstimate";
-
     private DruidPostAggregator field;
+    private Integer errorBoundsStdDev;
 
-    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    private int errorBoundsStdDev;
-
-    public ThetaSketchEstimatePostAggregator(@NonNull String name,
-                                             @NonNull DruidPostAggregator field) {
-        this.type = THETA_SKETCH_ESTIMATE_POST_AGGREGATOR_TYPE;
-        this.name = name;
-        this.field = field;
-    }
-
-    public ThetaSketchEstimatePostAggregator(@NonNull String name,
-                                             @NonNull DruidPostAggregator field,
-                                             int errorBoundsStdDev) {
+    @Builder
+    public ThetaSketchEstimatePostAggregator(
+            @NonNull String name,
+            @NonNull DruidPostAggregator field,
+            Integer errorBoundsStdDev) {
         this.type = THETA_SKETCH_ESTIMATE_POST_AGGREGATOR_TYPE;
         this.name = name;
         this.field = field;

--- a/src/main/java/in/zapr/druid/druidry/extensions/datasketches/postAggregator/ThetaSketchEstimatePostAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/extensions/datasketches/postAggregator/ThetaSketchEstimatePostAggregator.java
@@ -16,6 +16,7 @@
 
 package in.zapr.druid.druidry.extensions.datasketches.postAggregator;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import in.zapr.druid.druidry.postAggregator.DruidPostAggregator;
 import lombok.Getter;
 import lombok.NonNull;
@@ -27,11 +28,23 @@ public class ThetaSketchEstimatePostAggregator extends DruidPostAggregator {
 
     private DruidPostAggregator field;
 
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    private int errorBoundsStdDev;
+
     public ThetaSketchEstimatePostAggregator(@NonNull String name,
                                              @NonNull DruidPostAggregator field) {
         this.type = THETA_SKETCH_ESTIMATE_POST_AGGREGATOR_TYPE;
         this.name = name;
         this.field = field;
+    }
+
+    public ThetaSketchEstimatePostAggregator(@NonNull String name,
+                                             @NonNull DruidPostAggregator field,
+                                             int errorBoundsStdDev) {
+        this.type = THETA_SKETCH_ESTIMATE_POST_AGGREGATOR_TYPE;
+        this.name = name;
+        this.field = field;
+        this.errorBoundsStdDev = errorBoundsStdDev;
     }
 
 }

--- a/src/main/java/in/zapr/druid/druidry/query/aggregation/DruidGroupByQuery.java
+++ b/src/main/java/in/zapr/druid/druidry/query/aggregation/DruidGroupByQuery.java
@@ -41,13 +41,11 @@ public class DruidGroupByQuery extends DruidAggregationQuery {
 
     private DefaultLimitSpec limitSpec;
     private String having;
-
-    @NonNull
     private List<DruidDimension> dimensions;
 
     @Builder
     private DruidGroupByQuery(@NonNull String dataSource,
-                              @NonNull List<DruidDimension> dimensions,
+                              List<DruidDimension> dimensions,
                               DefaultLimitSpec limitSpec,
                               @NonNull Granularity granularity,
                               DruidFilter filter,

--- a/src/main/java/in/zapr/druid/druidry/query/aggregation/DruidGroupByQuery.java
+++ b/src/main/java/in/zapr/druid/druidry/query/aggregation/DruidGroupByQuery.java
@@ -41,11 +41,12 @@ public class DruidGroupByQuery extends DruidAggregationQuery {
 
     private DefaultLimitSpec limitSpec;
     private String having;
+    @NonNull
     private List<DruidDimension> dimensions;
 
     @Builder
     private DruidGroupByQuery(@NonNull String dataSource,
-                              List<DruidDimension> dimensions,
+                              @NonNull List<DruidDimension> dimensions,
                               DefaultLimitSpec limitSpec,
                               @NonNull Granularity granularity,
                               DruidFilter filter,

--- a/src/test/java/in/zapr/druid/druidry/extensions/datasketches/postAggregator/ThetaSketchEstimatePostAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/extensions/datasketches/postAggregator/ThetaSketchEstimatePostAggregatorTest.java
@@ -51,7 +51,7 @@ public class ThetaSketchEstimatePostAggregatorTest {
     }
 
     @Test
-    public void testAllFieldsWithFieldAccess() throws JsonProcessingException, JSONException {
+    public void testRequiredFieldsWithFieldAccess() throws JsonProcessingException, JSONException {
 
         FieldAccessPostAggregator fieldAccessPostAggregator =
                 new FieldAccessPostAggregator("stars");
@@ -65,6 +65,30 @@ public class ThetaSketchEstimatePostAggregatorTest {
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "thetaSketchEstimate");
         jsonObject.put("name", "estimate_stars");
+        jsonObject.put("field", fieldAccess);
+
+        String actualJSON = objectMapper.writeValueAsString(thetaSketchEstimatePostAggregator);
+        String expectedJSON = jsonObject.toString();
+        JSONAssert.assertEquals(expectedJSON, actualJSON, JSONCompareMode.NON_EXTENSIBLE);
+
+    }
+
+    @Test
+    public void testAllFieldsWithFieldAccess() throws JsonProcessingException, JSONException {
+
+        FieldAccessPostAggregator fieldAccessPostAggregator =
+                new FieldAccessPostAggregator("stars");
+
+        ThetaSketchEstimatePostAggregator thetaSketchEstimatePostAggregator =
+                new ThetaSketchEstimatePostAggregator("estimate_stars", fieldAccessPostAggregator, 2);
+
+
+        JSONObject fieldAccess = getFieldAccessJSON();
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("type", "thetaSketchEstimate");
+        jsonObject.put("name", "estimate_stars");
+        jsonObject.put("errorBoundsStdDev", 2);
         jsonObject.put("field", fieldAccess);
 
         String actualJSON = objectMapper.writeValueAsString(thetaSketchEstimatePostAggregator);


### PR DESCRIPTION
Add errorBoundsStdDev to ThetaSketch postAggregation. Allow dimensions to be null in GroupByQuery as they are not required.

With dimensions needing to be NonNull, I've been writing a bunch of code like:
` DruidGroupByQuery.builder().dimensions(Collections.emptyList())....`
