### PR TITLE
add support all types dataSource

### DIFF
--- a/src/main/java/in/zapr/druid/druidry/dataSource/DataSource.java
+++ b/src/main/java/in/zapr/druid/druidry/dataSource/DataSource.java
@@ -14,27 +14,24 @@
  * limitations under the License.
  */
 
-package in.zapr.druid.druidry.query;
+package in.zapr.druid.druidry.dataSource;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-
-import in.zapr.druid.druidry.Context;
-import in.zapr.druid.druidry.dataSource.DataSource;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 
+/**
+ * Generate datasource for druid query. See documentation
+ * <a href="http://druid.io/docs/latest/querying/datasource.html">
+ *     http://druid.io/docs/latest/querying/datasource.html
+ * </a>
+ */
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
-public abstract class DruidQuery {
+public abstract class DataSource {
 
     @NonNull
-    protected DataSource dataSource;
-
-    protected Context context;
-
-    // Not making it public since this should be set by its children's constructor.
-    @NonNull
-    protected QueryType queryType;
+    protected DataSourceType type;
 }

--- a/src/main/java/in/zapr/druid/druidry/dataSource/DataSource.java
+++ b/src/main/java/in/zapr/druid/druidry/dataSource/DataSource.java
@@ -17,6 +17,7 @@
 package in.zapr.druid.druidry.dataSource;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
@@ -24,7 +25,7 @@ import lombok.NonNull;
 /**
  * Generate datasource for druid query. See documentation
  * <a href="http://druid.io/docs/latest/querying/datasource.html">
- *     http://druid.io/docs/latest/querying/datasource.html
+ * http://druid.io/docs/latest/querying/datasource.html
  * </a>
  */
 @Getter

--- a/src/main/java/in/zapr/druid/druidry/dataSource/DataSourceType.java
+++ b/src/main/java/in/zapr/druid/druidry/dataSource/DataSourceType.java
@@ -14,27 +14,24 @@
  * limitations under the License.
  */
 
-package in.zapr.druid.druidry.query;
+package in.zapr.druid.druidry.dataSource;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonValue;
 
-import in.zapr.druid.druidry.Context;
-import in.zapr.druid.druidry.dataSource.DataSource;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NonNull;
+public enum DataSourceType {
 
-@Getter
-@JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
-public abstract class DruidQuery {
+    TABLE("table"),
+    UNION("union"),
+    QUERY("query");
 
-    @NonNull
-    protected DataSource dataSource;
+    private String value;
 
-    protected Context context;
+    DataSourceType(String value) {
+        this.value = value;
+    }
 
-    // Not making it public since this should be set by its children's constructor.
-    @NonNull
-    protected QueryType queryType;
+    @JsonValue
+    public String getQueryType() {
+        return value;
+    }
 }

--- a/src/main/java/in/zapr/druid/druidry/dataSource/QueryDataSource.java
+++ b/src/main/java/in/zapr/druid/druidry/dataSource/QueryDataSource.java
@@ -14,27 +14,26 @@
  * limitations under the License.
  */
 
-package in.zapr.druid.druidry.query;
+package in.zapr.druid.druidry.dataSource;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-
-import in.zapr.druid.druidry.Context;
-import in.zapr.druid.druidry.dataSource.DataSource;
+import in.zapr.druid.druidry.query.DruidQuery;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
-public abstract class DruidQuery {
+@EqualsAndHashCode(callSuper = true)
+public class QueryDataSource extends DataSource{
 
     @NonNull
-    protected DataSource dataSource;
+    private DruidQuery query;
 
-    protected Context context;
-
-    // Not making it public since this should be set by its children's constructor.
-    @NonNull
-    protected QueryType queryType;
+    @Builder
+    public QueryDataSource(@NonNull DruidQuery query) {
+        this.type = DataSourceType.QUERY;
+        this.query = query;
+    }
 }

--- a/src/main/java/in/zapr/druid/druidry/dataSource/QueryDataSource.java
+++ b/src/main/java/in/zapr/druid/druidry/dataSource/QueryDataSource.java
@@ -17,6 +17,7 @@
 package in.zapr.druid.druidry.dataSource;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+
 import in.zapr.druid.druidry.query.DruidQuery;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -26,7 +27,7 @@ import lombok.NonNull;
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode(callSuper = true)
-public class QueryDataSource extends DataSource{
+public class QueryDataSource extends DataSource {
 
     @NonNull
     private DruidQuery query;

--- a/src/main/java/in/zapr/druid/druidry/dataSource/TableDataSource.java
+++ b/src/main/java/in/zapr/druid/druidry/dataSource/TableDataSource.java
@@ -17,6 +17,7 @@
 package in.zapr.druid.druidry.dataSource;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -25,7 +26,7 @@ import lombok.NonNull;
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode(callSuper = true)
-public class TableDataSource extends DataSource{
+public class TableDataSource extends DataSource {
 
     @NonNull
     private String name;

--- a/src/main/java/in/zapr/druid/druidry/dataSource/TableDataSource.java
+++ b/src/main/java/in/zapr/druid/druidry/dataSource/TableDataSource.java
@@ -14,27 +14,25 @@
  * limitations under the License.
  */
 
-package in.zapr.druid.druidry.query;
+package in.zapr.druid.druidry.dataSource;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-
-import in.zapr.druid.druidry.Context;
-import in.zapr.druid.druidry.dataSource.DataSource;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
-public abstract class DruidQuery {
+@EqualsAndHashCode(callSuper = true)
+public class TableDataSource extends DataSource{
 
     @NonNull
-    protected DataSource dataSource;
+    private String name;
 
-    protected Context context;
-
-    // Not making it public since this should be set by its children's constructor.
-    @NonNull
-    protected QueryType queryType;
+    @Builder
+    public TableDataSource(@NonNull String name) {
+        this.type = DataSourceType.TABLE;
+        this.name = name;
+    }
 }

--- a/src/main/java/in/zapr/druid/druidry/dataSource/UnionDataSource.java
+++ b/src/main/java/in/zapr/druid/druidry/dataSource/UnionDataSource.java
@@ -17,17 +17,18 @@
 package in.zapr.druid.druidry.dataSource;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 
-import java.util.List;
-
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode(callSuper = true)
-public class UnionDataSource extends DataSource{
+public class UnionDataSource extends DataSource {
 
     @NonNull
     private List<String> dataSources;

--- a/src/main/java/in/zapr/druid/druidry/dataSource/UnionDataSource.java
+++ b/src/main/java/in/zapr/druid/druidry/dataSource/UnionDataSource.java
@@ -14,27 +14,27 @@
  * limitations under the License.
  */
 
-package in.zapr.druid.druidry.query;
+package in.zapr.druid.druidry.dataSource;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-
-import in.zapr.druid.druidry.Context;
-import in.zapr.druid.druidry.dataSource.DataSource;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 
+import java.util.List;
+
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
-public abstract class DruidQuery {
+@EqualsAndHashCode(callSuper = true)
+public class UnionDataSource extends DataSource{
 
     @NonNull
-    protected DataSource dataSource;
+    private List<String> dataSources;
 
-    protected Context context;
-
-    // Not making it public since this should be set by its children's constructor.
-    @NonNull
-    protected QueryType queryType;
+    @Builder
+    public UnionDataSource(@NonNull List<String> dataSources) {
+        this.type = DataSourceType.UNION;
+        this.dataSources = dataSources;
+    }
 }

--- a/src/main/java/in/zapr/druid/druidry/extensions/histogram/aggregator/QuantilePostAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/extensions/histogram/aggregator/QuantilePostAggregator.java
@@ -17,6 +17,7 @@
 package in.zapr.druid.druidry.extensions.histogram.aggregator;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+
 import in.zapr.druid.druidry.postAggregator.DruidPostAggregator;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/in/zapr/druid/druidry/query/aggregation/DruidGroupByQuery.java
+++ b/src/main/java/in/zapr/druid/druidry/query/aggregation/DruidGroupByQuery.java
@@ -23,6 +23,7 @@ import java.util.List;
 import in.zapr.druid.druidry.Context;
 import in.zapr.druid.druidry.Interval;
 import in.zapr.druid.druidry.aggregator.DruidAggregator;
+import in.zapr.druid.druidry.dataSource.DataSource;
 import in.zapr.druid.druidry.dimension.DruidDimension;
 import in.zapr.druid.druidry.filter.DruidFilter;
 import in.zapr.druid.druidry.granularity.Granularity;
@@ -46,7 +47,7 @@ public class DruidGroupByQuery extends DruidAggregationQuery {
     private List<DruidDimension> dimensions;
 
     @Builder
-    private DruidGroupByQuery(@NonNull String dataSource,
+    private DruidGroupByQuery(@NonNull DataSource dataSource,
                               @NonNull List<DruidDimension> dimensions,
                               DefaultLimitSpec limitSpec,
                               @NonNull Granularity granularity,

--- a/src/main/java/in/zapr/druid/druidry/query/aggregation/DruidTimeSeriesQuery.java
+++ b/src/main/java/in/zapr/druid/druidry/query/aggregation/DruidTimeSeriesQuery.java
@@ -23,6 +23,7 @@ import java.util.List;
 import in.zapr.druid.druidry.Context;
 import in.zapr.druid.druidry.Interval;
 import in.zapr.druid.druidry.aggregator.DruidAggregator;
+import in.zapr.druid.druidry.dataSource.DataSource;
 import in.zapr.druid.druidry.filter.DruidFilter;
 import in.zapr.druid.druidry.granularity.Granularity;
 import in.zapr.druid.druidry.postAggregator.DruidPostAggregator;
@@ -40,7 +41,7 @@ public class DruidTimeSeriesQuery extends DruidAggregationQuery {
     private Boolean descending;
 
     @Builder
-    private DruidTimeSeriesQuery(@NonNull String dataSource, Boolean descending,
+    private DruidTimeSeriesQuery(@NonNull DataSource dataSource, Boolean descending,
                                  @NonNull List<Interval> intervals, @NonNull Granularity granularity,
                                  DruidFilter filter, List<DruidAggregator> aggregators,
                                  List<DruidPostAggregator> postAggregators, Context context) {

--- a/src/main/java/in/zapr/druid/druidry/query/aggregation/DruidTopNQuery.java
+++ b/src/main/java/in/zapr/druid/druidry/query/aggregation/DruidTopNQuery.java
@@ -25,6 +25,7 @@ import java.util.List;
 import in.zapr.druid.druidry.Context;
 import in.zapr.druid.druidry.Interval;
 import in.zapr.druid.druidry.aggregator.DruidAggregator;
+import in.zapr.druid.druidry.dataSource.DataSource;
 import in.zapr.druid.druidry.dimension.DruidDimension;
 import in.zapr.druid.druidry.filter.DruidFilter;
 import in.zapr.druid.druidry.granularity.Granularity;
@@ -46,7 +47,7 @@ public class DruidTopNQuery extends DruidAggregationQuery {
     private TopNMetric metric;
 
     @Builder
-    private DruidTopNQuery(@NonNull String dataSource,
+    private DruidTopNQuery(@NonNull DataSource dataSource,
                            @NonNull List<Interval> intervals,
                            @NonNull Granularity granularity,
                            DruidFilter filter,

--- a/src/main/java/in/zapr/druid/druidry/query/scan/DruidScanQuery.java
+++ b/src/main/java/in/zapr/druid/druidry/query/scan/DruidScanQuery.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import in.zapr.druid.druidry.Context;
 import in.zapr.druid.druidry.Interval;
+import in.zapr.druid.druidry.dataSource.DataSource;
 import in.zapr.druid.druidry.filter.DruidFilter;
 import in.zapr.druid.druidry.query.DruidQuery;
 import in.zapr.druid.druidry.query.QueryType;
@@ -46,7 +47,7 @@ public class DruidScanQuery extends DruidQuery {
     private Boolean legacy;
 
     @Builder
-    private DruidScanQuery(@NonNull String dataSource, DruidFilter filter, Integer batchSize, @NonNull List<Interval> intervals, List<String> columns, ResultFormat resultFormat, Long limit, Boolean legacy, Context context) {
+    private DruidScanQuery(@NonNull DataSource dataSource, DruidFilter filter, Integer batchSize, @NonNull List<Interval> intervals, List<String> columns, ResultFormat resultFormat, Long limit, Boolean legacy, Context context) {
         this.filter = filter;
         this.intervals = intervals;
         this.columns = columns;

--- a/src/main/java/in/zapr/druid/druidry/query/search/DruidSearchQuery.java
+++ b/src/main/java/in/zapr/druid/druidry/query/search/DruidSearchQuery.java
@@ -24,6 +24,7 @@ import java.util.List;
 import in.zapr.druid.druidry.Context;
 import in.zapr.druid.druidry.Interval;
 import in.zapr.druid.druidry.SortingOrder;
+import in.zapr.druid.druidry.dataSource.DataSource;
 import in.zapr.druid.druidry.dimension.DruidDimension;
 import in.zapr.druid.druidry.filter.DruidFilter;
 import in.zapr.druid.druidry.filter.searchQuerySpec.SearchQuerySpec;
@@ -49,7 +50,7 @@ public class DruidSearchQuery extends DruidQuery {
     private SearchSortSpec sort;
 
     @Builder
-    private DruidSearchQuery(@NonNull String dataSource,
+    private DruidSearchQuery(@NonNull DataSource dataSource,
                              @NonNull Granularity granularity,
                              DruidFilter filter,
                              Integer limit,

--- a/src/main/java/in/zapr/druid/druidry/query/select/DruidSelectQuery.java
+++ b/src/main/java/in/zapr/druid/druidry/query/select/DruidSelectQuery.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import in.zapr.druid.druidry.Context;
 import in.zapr.druid.druidry.Interval;
+import in.zapr.druid.druidry.dataSource.DataSource;
 import in.zapr.druid.druidry.dimension.DruidDimension;
 import in.zapr.druid.druidry.filter.DruidFilter;
 import in.zapr.druid.druidry.granularity.Granularity;
@@ -48,7 +49,7 @@ public class DruidSelectQuery extends DruidQuery {
 
     @Builder
     public DruidSelectQuery(
-            @NonNull String dataSource,
+            @NonNull DataSource dataSource,
             DruidFilter filter,
             Boolean descending,
             Granularity granularity,

--- a/src/test/java/in/zapr/druid/druidry/dataSource/QueryDataSourceTest.java
+++ b/src/test/java/in/zapr/druid/druidry/dataSource/QueryDataSourceTest.java
@@ -18,13 +18,7 @@ package in.zapr.druid.druidry.dataSource;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import in.zapr.druid.druidry.Interval;
-import in.zapr.druid.druidry.dimension.DruidDimension;
-import in.zapr.druid.druidry.dimension.SimpleDimension;
-import in.zapr.druid.druidry.granularity.Granularity;
-import in.zapr.druid.druidry.granularity.PredefinedGranularity;
-import in.zapr.druid.druidry.granularity.SimpleGranularity;
-import in.zapr.druid.druidry.query.aggregation.DruidGroupByQuery;
+
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.JSONArray;
@@ -37,6 +31,14 @@ import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+
+import in.zapr.druid.druidry.Interval;
+import in.zapr.druid.druidry.dimension.DruidDimension;
+import in.zapr.druid.druidry.dimension.SimpleDimension;
+import in.zapr.druid.druidry.granularity.Granularity;
+import in.zapr.druid.druidry.granularity.PredefinedGranularity;
+import in.zapr.druid.druidry.granularity.SimpleGranularity;
+import in.zapr.druid.druidry.query.aggregation.DruidGroupByQuery;
 
 public class QueryDataSourceTest {
     private static ObjectMapper objectMapper;

--- a/src/test/java/in/zapr/druid/druidry/dataSource/QueryDataSourceTest.java
+++ b/src/test/java/in/zapr/druid/druidry/dataSource/QueryDataSourceTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018-present Red Brick Lane Marketing Solutions Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package in.zapr.druid.druidry.dataSource;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import in.zapr.druid.druidry.Interval;
+import in.zapr.druid.druidry.dimension.DruidDimension;
+import in.zapr.druid.druidry.dimension.SimpleDimension;
+import in.zapr.druid.druidry.granularity.Granularity;
+import in.zapr.druid.druidry.granularity.PredefinedGranularity;
+import in.zapr.druid.druidry.granularity.SimpleGranularity;
+import in.zapr.druid.druidry.query.aggregation.DruidGroupByQuery;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class QueryDataSourceTest {
+    private static ObjectMapper objectMapper;
+
+    @BeforeClass
+    public void init() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void testQueryDataSource() throws JsonProcessingException, JSONException {
+        DruidDimension druidDimension1 = new SimpleDimension("dim1");
+        DruidDimension druidDimension2 = new SimpleDimension("dim2");
+
+        Granularity granularity = new SimpleGranularity(PredefinedGranularity.ALL);
+        // Interval
+        DateTime startTime = new DateTime(2012, 1, 1, 0, 0, 0, DateTimeZone.UTC);
+        DateTime endTime = new DateTime(2012, 1, 3, 0, 0, 0, DateTimeZone.UTC);
+        Interval interval = new Interval(startTime, endTime);
+
+        DruidGroupByQuery druidGroupByQuery = DruidGroupByQuery.builder()
+                .dataSource(new TableDataSource("sample_datasource"))
+                .dimensions(Arrays.asList(druidDimension1, druidDimension2))
+                .granularity(granularity)
+                .intervals(Collections.singletonList(interval))
+                .build();
+
+        QueryDataSource queryDataSource = new QueryDataSource(druidGroupByQuery);
+
+        JSONObject dataSource = new JSONObject();
+        dataSource.put("type", "table");
+        dataSource.put("name", "sample_datasource");
+
+        JSONObject expectedQuery = new JSONObject();
+        expectedQuery.put("queryType", "groupBy");
+        expectedQuery.put("dataSource", dataSource);
+
+        JSONArray intervalArray = new JSONArray(Collections.singletonList("2012-01-01T00:00:00.000Z/2012-01-03T00:00:00.000Z"));
+        expectedQuery.put("intervals", intervalArray);
+        expectedQuery.put("granularity", "all");
+        JSONArray dimensionArray = new JSONArray(Arrays.asList("dim1", "dim2"));
+        expectedQuery.put("dimensions", dimensionArray);
+
+        JSONObject queryDataSourceJson = new JSONObject();
+        queryDataSourceJson.put("type", "query");
+        queryDataSourceJson.put("query", expectedQuery);
+
+        String actualJson = objectMapper.writeValueAsString(queryDataSource);
+        JSONAssert.assertEquals(actualJson, queryDataSourceJson, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullableDataSourceQuery() {
+        new QueryDataSource(null);
+    }
+}
+

--- a/src/test/java/in/zapr/druid/druidry/dataSource/TableDataSourceTest.java
+++ b/src/test/java/in/zapr/druid/druidry/dataSource/TableDataSourceTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018-present Red Brick Lane Marketing Solutions Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package in.zapr.druid.druidry.dataSource;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import in.zapr.druid.druidry.Interval;
+import in.zapr.druid.druidry.granularity.Granularity;
+import in.zapr.druid.druidry.granularity.PredefinedGranularity;
+import in.zapr.druid.druidry.granularity.SimpleGranularity;
+import in.zapr.druid.druidry.query.select.DruidSelectQuery;
+import in.zapr.druid.druidry.query.select.PagingSpec;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+public class TableDataSourceTest {
+    private static ObjectMapper objectMapper;
+
+    @BeforeClass
+    public void init() {
+        objectMapper = new ObjectMapper();
+    }
+
+
+    @Test
+    public void testTableDataSource() throws JsonProcessingException, JSONException {
+        TableDataSource tableDataSource = new TableDataSource("sample_datasource");
+
+        JSONObject dataSource = new JSONObject();
+        dataSource.put("type", "table");
+        dataSource.put("name", "sample_datasource");
+
+        String actualJson = objectMapper.writeValueAsString(tableDataSource);
+        JSONAssert.assertEquals(actualJson, dataSource, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullableDataSourceName() {
+        new TableDataSource(null);
+    }
+}
+

--- a/src/test/java/in/zapr/druid/druidry/dataSource/TableDataSourceTest.java
+++ b/src/test/java/in/zapr/druid/druidry/dataSource/TableDataSourceTest.java
@@ -18,24 +18,13 @@ package in.zapr.druid.druidry.dataSource;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import in.zapr.druid.druidry.Interval;
-import in.zapr.druid.druidry.granularity.Granularity;
-import in.zapr.druid.druidry.granularity.PredefinedGranularity;
-import in.zapr.druid.druidry.granularity.SimpleGranularity;
-import in.zapr.druid.druidry.query.select.DruidSelectQuery;
-import in.zapr.druid.druidry.query.select.PagingSpec;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.json.JSONArray;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import java.util.Collections;
-import java.util.HashMap;
 
 public class TableDataSourceTest {
     private static ObjectMapper objectMapper;

--- a/src/test/java/in/zapr/druid/druidry/dataSource/UnionDataSourceTest.java
+++ b/src/test/java/in/zapr/druid/druidry/dataSource/UnionDataSourceTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018-present Red Brick Lane Marketing Solutions Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package in.zapr.druid.druidry.dataSource;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class UnionDataSourceTest {
+    private static ObjectMapper objectMapper;
+
+    @BeforeClass
+    public void init() {
+        objectMapper = new ObjectMapper();
+    }
+
+
+    @Test
+    public void testUnionDataSource() throws JsonProcessingException, JSONException {
+        List<String> dataSourcesList = Arrays.asList("datasource_1", "datasource_2");
+
+        UnionDataSource unionDataSource = new UnionDataSource(dataSourcesList);
+
+        JSONObject dataSource = new JSONObject();
+        dataSource.put("type", "union");
+
+        JSONArray dataSources = new JSONArray(dataSourcesList);
+        dataSource.put("dataSources", dataSources);
+
+        String actualJson = objectMapper.writeValueAsString(unionDataSource);
+        JSONAssert.assertEquals(actualJson, dataSource, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullableDataSourceList() {
+        new UnionDataSource(null);
+    }
+}
+

--- a/src/test/java/in/zapr/druid/druidry/dataSource/UnionDataSourceTest.java
+++ b/src/test/java/in/zapr/druid/druidry/dataSource/UnionDataSourceTest.java
@@ -18,6 +18,7 @@ package in.zapr.druid.druidry.dataSource;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/src/test/java/in/zapr/druid/druidry/extensions/histogram/aggregator/ApproxHistogramAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/extensions/histogram/aggregator/ApproxHistogramAggregatorTest.java
@@ -16,15 +16,16 @@
 
 package in.zapr.druid.druidry.extensions.histogram.aggregator;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import in.zapr.druid.druidry.extensions.histogram.aggregator.ApproxHistogramAggregator;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -34,8 +35,8 @@ public class ApproxHistogramAggregatorTest {
 
     @BeforeClass
     public void init() {
-    objectMapper = new ObjectMapper();
-  }
+        objectMapper = new ObjectMapper();
+    }
 
     @Test
     public void testAllFields() throws JsonProcessingException, JSONException {
@@ -66,15 +67,15 @@ public class ApproxHistogramAggregatorTest {
     @Test(expectedExceptions = NullPointerException.class)
     public void testNullName() {
         ApproxHistogramAggregator approxHistogramAgg = ApproxHistogramAggregator.builder().name(null)
-            .fieldName("_loadtime").resolution(100).lowerLimit(Float.NEGATIVE_INFINITY)
-            .upperLimit(Float.POSITIVE_INFINITY).numberOfBuckets(10).build();
+                .fieldName("_loadtime").resolution(100).lowerLimit(Float.NEGATIVE_INFINITY)
+                .upperLimit(Float.POSITIVE_INFINITY).numberOfBuckets(10).build();
 
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void testNullFieldName() {
         ApproxHistogramAggregator approxHistogramAgg =
-            ApproxHistogramAggregator.builder().name("druidry").fieldName(null).resolution(100)
-                .lowerLimit(Float.NEGATIVE_INFINITY).upperLimit(Float.POSITIVE_INFINITY).build();
+                ApproxHistogramAggregator.builder().name("druidry").fieldName(null).resolution(100)
+                        .lowerLimit(Float.NEGATIVE_INFINITY).upperLimit(Float.POSITIVE_INFINITY).build();
     }
 }

--- a/src/test/java/in/zapr/druid/druidry/extensions/histogram/aggregator/ApproxHistogramFoldAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/extensions/histogram/aggregator/ApproxHistogramFoldAggregatorTest.java
@@ -83,5 +83,5 @@ public class ApproxHistogramFoldAggregatorTest {
                         .lowerLimit(Float.NEGATIVE_INFINITY)
                         .upperLimit(Float.POSITIVE_INFINITY)
                         .build();
-  }
+    }
 }

--- a/src/test/java/in/zapr/druid/druidry/extensions/histogram/aggregator/QuantilePostAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/extensions/histogram/aggregator/QuantilePostAggregatorTest.java
@@ -16,15 +16,16 @@
 
 package in.zapr.druid.druidry.extensions.histogram.aggregator;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import in.zapr.druid.druidry.extensions.histogram.aggregator.QuantilePostAggregator;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -34,14 +35,14 @@ public class QuantilePostAggregatorTest {
 
     @BeforeClass
     public void init() {
-    objectMapper = new ObjectMapper();
-  }
+        objectMapper = new ObjectMapper();
+    }
 
     @Test
     public void testAllFields() throws JsonProcessingException, JSONException {
 
         QuantilePostAggregator quantilePostAgg = QuantilePostAggregator.builder().name("quantile")
-            .fieldName("timeAgg").probability(0.50F).build();
+                .fieldName("timeAgg").probability(0.50F).build();
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "quantile");
@@ -57,12 +58,12 @@ public class QuantilePostAggregatorTest {
     @Test(expectedExceptions = NullPointerException.class)
     public void testNullName() throws JsonProcessingException, JSONException {
         QuantilePostAggregator quantilePostAgg =
-            QuantilePostAggregator.builder().name(null).fieldName("timeAgg").probability(0.50F).build();
+                QuantilePostAggregator.builder().name(null).fieldName("timeAgg").probability(0.50F).build();
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void testNullFieldName() throws JsonProcessingException, JSONException {
         QuantilePostAggregator quantilePostAgg = QuantilePostAggregator.builder().name("quantile")
-            .fieldName(null).probability(0.50F).build();
+                .fieldName(null).probability(0.50F).build();
     }
 }

--- a/src/test/java/in/zapr/druid/druidry/extensions/histogram/postAggregator/CustomBucketsPostAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/extensions/histogram/postAggregator/CustomBucketsPostAggregatorTest.java
@@ -16,20 +16,21 @@
 
 package in.zapr.druid.druidry.extensions.histogram.postAggregator;
 
-import java.util.HashSet;
-import java.util.Set;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
-import org.skyscreamer.jsonassert.comparator.ArraySizeComparator;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import in.zapr.druid.druidry.extensions.histogram.postAggregator.CustomBucketsPostAggregator;
+
+import java.util.HashSet;
+import java.util.Set;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -49,7 +50,7 @@ public class CustomBucketsPostAggregatorTest {
     public void testAllFields() throws JsonProcessingException, JSONException {
 
         CustomBucketsPostAggregator customBucketsPostAgg = CustomBucketsPostAggregator.builder()
-            .name("custom_buckets").fieldName("_loadtime").breaks(breaks).build();
+                .name("custom_buckets").fieldName("_loadtime").breaks(breaks).build();
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "customBuckets");
@@ -66,12 +67,12 @@ public class CustomBucketsPostAggregatorTest {
     @Test(expectedExceptions = NullPointerException.class)
     public void testNullName() {
         CustomBucketsPostAggregator customBucketsPostAgg = CustomBucketsPostAggregator.builder()
-            .name(null).fieldName("_loadtime").breaks(breaks).build();
+                .name(null).fieldName("_loadtime").breaks(breaks).build();
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void testNullFieldName() {
         CustomBucketsPostAggregator customBucketsPostAgg = CustomBucketsPostAggregator.builder()
-            .name("custom_buckets").fieldName(null).breaks(breaks).build();
+                .name("custom_buckets").fieldName(null).breaks(breaks).build();
     }
 }

--- a/src/test/java/in/zapr/druid/druidry/extensions/histogram/postAggregator/QuantilesPostAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/extensions/histogram/postAggregator/QuantilesPostAggregatorTest.java
@@ -50,7 +50,7 @@ public class QuantilesPostAggregatorTest {
     public void testAllFields() throws JsonProcessingException, JSONException {
 
         QuantilesPostAggregator quantilesPostAgg = QuantilesPostAggregator.builder().name("quantiles")
-            .fieldName("timeAgg").probabilities(probabilities).build();
+                .fieldName("timeAgg").probabilities(probabilities).build();
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "quantiles");
@@ -67,12 +67,12 @@ public class QuantilesPostAggregatorTest {
     @Test(expectedExceptions = NullPointerException.class)
     public void testNullName() {
         QuantilesPostAggregator quantilesPostAgg = QuantilesPostAggregator.builder().name(null)
-            .fieldName("timeAgg").probabilities(probabilities).build();
+                .fieldName("timeAgg").probabilities(probabilities).build();
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void testNullFieldName() {
         QuantilesPostAggregator quantilesPostAgg = QuantilesPostAggregator.builder().name("quantiles")
-            .fieldName(null).probabilities(probabilities).build();
+                .fieldName(null).probabilities(probabilities).build();
     }
 }

--- a/src/test/java/in/zapr/druid/druidry/query/aggregation/GroupByTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/aggregation/GroupByTest.java
@@ -19,7 +19,6 @@ package in.zapr.druid.druidry.query.aggregation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import in.zapr.druid.druidry.dataSource.TableDataSource;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.JSONArray;
@@ -40,6 +39,7 @@ import in.zapr.druid.druidry.aggregator.CountAggregator;
 import in.zapr.druid.druidry.aggregator.DoubleSumAggregator;
 import in.zapr.druid.druidry.aggregator.DruidAggregator;
 import in.zapr.druid.druidry.aggregator.LongSumAggregator;
+import in.zapr.druid.druidry.dataSource.TableDataSource;
 import in.zapr.druid.druidry.dimension.DruidDimension;
 import in.zapr.druid.druidry.dimension.SimpleDimension;
 import in.zapr.druid.druidry.filter.AndFilter;

--- a/src/test/java/in/zapr/druid/druidry/query/aggregation/GroupByTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/aggregation/GroupByTest.java
@@ -19,6 +19,7 @@ package in.zapr.druid.druidry.query.aggregation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import in.zapr.druid.druidry.dataSource.TableDataSource;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.JSONArray;
@@ -69,7 +70,10 @@ public class GroupByTest {
     public void testSampleQuery() throws JsonProcessingException, JSONException {
         String expectedJsonAsString = "{\n" +
                 "  \"queryType\": \"groupBy\",\n" +
-                "  \"dataSource\": \"sample_datasource\",\n" +
+                "  \"dataSource\": {\n" +
+                "    \"type\": \"table\",\n" +
+                "    \"name\": \"sample_datasource\"\n" +
+                "  },\n" +
                 "  \"granularity\": \"day\",\n" +
                 "  \"dimensions\": [\"country\", \"device\"],\n" +
                 "  \"limitSpec\": { \"type\": \"default\", \"limit\": 5000, \"columns\": [\"country\", \"data_transfer\"] },\n" +
@@ -140,7 +144,7 @@ public class GroupByTest {
         Interval interval = new Interval(startTime, endTime);
 
         DruidGroupByQuery query = DruidGroupByQuery.builder()
-                .dataSource("sample_datasource")
+                .dataSource(new TableDataSource("sample_datasource"))
                 .granularity(new SimpleGranularity(PredefinedGranularity.DAY))
                 .dimensions(Arrays.asList(druidDimension1, druidDimension2))
                 .limitSpec(limitSpec)
@@ -166,7 +170,7 @@ public class GroupByTest {
         Interval interval = new Interval(startTime, endTime);
 
         DruidGroupByQuery druidGroupByQuery = DruidGroupByQuery.builder()
-                .dataSource("sample_datasource")
+                .dataSource(new TableDataSource("sample_datasource"))
                 .dimensions(Arrays.asList(druidDimension1, druidDimension2))
                 .granularity(granularity)
                 .intervals(Collections.singletonList(interval))
@@ -174,9 +178,13 @@ public class GroupByTest {
 
         String actualJson = objectMapper.writeValueAsString(druidGroupByQuery);
 
+        JSONObject dataSource = new JSONObject();
+        dataSource.put("type", "table");
+        dataSource.put("name", "sample_datasource");
+
         JSONObject expectedQuery = new JSONObject();
         expectedQuery.put("queryType", "groupBy");
-        expectedQuery.put("dataSource", "sample_datasource");
+        expectedQuery.put("dataSource", dataSource);
 
         JSONArray intervalArray = new JSONArray(Collections.singletonList("2012-01-01T00:00:00.000Z/2012-01-03T00:00:00.000Z"));
         expectedQuery.put("intervals", intervalArray);
@@ -206,7 +214,7 @@ public class GroupByTest {
                 .build();
 
         DruidGroupByQuery druidGroupByQuery = DruidGroupByQuery.builder()
-                .dataSource("sample_datasource")
+                .dataSource(new TableDataSource("sample_datasource"))
                 .dimensions(Arrays.asList(druidDimension1, druidDimension2))
                 .granularity(granularity)
                 .filter(filter)
@@ -239,9 +247,13 @@ public class GroupByTest {
                 "2012-01-03T00:00:00.000Z"));
         JSONArray dimensionArray = new JSONArray(Arrays.asList("dim1", "dim2"));
 
+        JSONObject dataSource = new JSONObject();
+        dataSource.put("type", "table");
+        dataSource.put("name", "sample_datasource");
+
         JSONObject expectedQuery = new JSONObject();
         expectedQuery.put("queryType", "groupBy");
-        expectedQuery.put("dataSource", "sample_datasource");
+        expectedQuery.put("dataSource", dataSource);
         expectedQuery.put("dimensions", dimensionArray);
         expectedQuery.put("intervals", intervalArray);
         expectedQuery.put("granularity", "all");

--- a/src/test/java/in/zapr/druid/druidry/query/aggregation/TimeSeriesTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/aggregation/TimeSeriesTest.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 
-import in.zapr.druid.druidry.dataSource.TableDataSource;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.JSONArray;
@@ -40,6 +39,7 @@ import in.zapr.druid.druidry.aggregator.CountAggregator;
 import in.zapr.druid.druidry.aggregator.DoubleSumAggregator;
 import in.zapr.druid.druidry.aggregator.DruidAggregator;
 import in.zapr.druid.druidry.aggregator.LongSumAggregator;
+import in.zapr.druid.druidry.dataSource.TableDataSource;
 import in.zapr.druid.druidry.filter.AndFilter;
 import in.zapr.druid.druidry.filter.DruidFilter;
 import in.zapr.druid.druidry.filter.OrFilter;

--- a/src/test/java/in/zapr/druid/druidry/query/aggregation/TimeSeriesTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/aggregation/TimeSeriesTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 
+import in.zapr.druid.druidry.dataSource.TableDataSource;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.JSONArray;
@@ -105,7 +106,7 @@ public class TimeSeriesTest {
         Granularity granularity = new SimpleGranularity(PredefinedGranularity.DAY);
 
         DruidTimeSeriesQuery query = DruidTimeSeriesQuery.builder()
-                .dataSource("sample_datasource")
+                .dataSource(new TableDataSource("sample_datasource"))
                 .granularity(granularity)
                 .descending(true)
                 .filter(andFilter)
@@ -116,7 +117,10 @@ public class TimeSeriesTest {
 
         String expectedJsonAsString = "{\n" +
                 "  \"queryType\": \"timeseries\",\n" +
-                "  \"dataSource\": \"sample_datasource\",\n" +
+                "  \"dataSource\": {\n" +
+                "    \"type\": \"table\",\n" +
+                "    \"name\": \"sample_datasource\"\n" +
+                "  },\n" +
                 "  \"granularity\": \"day\",\n" +
                 "  \"descending\": true,\n" +
                 "  \"filter\": {\n" +
@@ -161,14 +165,18 @@ public class TimeSeriesTest {
         Granularity granularity = new SimpleGranularity(PredefinedGranularity.DAY);
 
         DruidTimeSeriesQuery seriesQuery = DruidTimeSeriesQuery.builder()
-                .dataSource("Matrix")
+                .dataSource(new TableDataSource("Matrix"))
                 .intervals(Collections.singletonList(interval))
                 .granularity(granularity)
                 .build();
 
+        JSONObject dataSource = new JSONObject();
+        dataSource.put("type", "table");
+        dataSource.put("name", "Matrix");
+
         JSONObject expectedQuery = new JSONObject();
         expectedQuery.put("queryType", "timeseries");
-        expectedQuery.put("dataSource", "Matrix");
+        expectedQuery.put("dataSource", dataSource);
         expectedQuery.put("intervals", new JSONArray(Collections
                 .singletonList("2013-07-14T00:00:00.000Z/2013-11-16T00:00:00.000Z")));
         expectedQuery.put("granularity", "day");
@@ -194,7 +202,7 @@ public class TimeSeriesTest {
         DruidPostAggregator postAggregator = new ConstantPostAggregator("Keep", 10.47);
 
         DruidTimeSeriesQuery seriesQuery = DruidTimeSeriesQuery.builder()
-                .dataSource("Matrix")
+                .dataSource(new TableDataSource("Matrix"))
                 .descending(true)
                 .intervals(Collections.singletonList(interval))
                 .granularity(granularity)
@@ -221,9 +229,13 @@ public class TimeSeriesTest {
         JSONObject expectedContext = new JSONObject();
         expectedContext.put("useCache", true);
 
+        JSONObject dataSource = new JSONObject();
+        dataSource.put("type", "table");
+        dataSource.put("name", "Matrix");
+
         JSONObject expectedQuery = new JSONObject();
         expectedQuery.put("queryType", "timeseries");
-        expectedQuery.put("dataSource", "Matrix");
+        expectedQuery.put("dataSource", dataSource);
         expectedQuery.put("intervals", new JSONArray(Collections
                 .singletonList("2013-07-14T00:00:00.000Z/2013-11-16T00:00:00.000Z")));
         expectedQuery.put("granularity", "day");

--- a/src/test/java/in/zapr/druid/druidry/query/aggregation/TopNQueryTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/aggregation/TopNQueryTest.java
@@ -19,7 +19,6 @@ package in.zapr.druid.druidry.query.aggregation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import in.zapr.druid.druidry.dataSource.TableDataSource;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.JSONArray;
@@ -40,6 +39,7 @@ import in.zapr.druid.druidry.aggregator.CountAggregator;
 import in.zapr.druid.druidry.aggregator.DoubleSumAggregator;
 import in.zapr.druid.druidry.aggregator.DruidAggregator;
 import in.zapr.druid.druidry.aggregator.LongSumAggregator;
+import in.zapr.druid.druidry.dataSource.TableDataSource;
 import in.zapr.druid.druidry.dimension.DruidDimension;
 import in.zapr.druid.druidry.dimension.SimpleDimension;
 import in.zapr.druid.druidry.filter.AndFilter;

--- a/src/test/java/in/zapr/druid/druidry/query/aggregation/TopNQueryTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/aggregation/TopNQueryTest.java
@@ -19,6 +19,7 @@ package in.zapr.druid.druidry.query.aggregation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import in.zapr.druid.druidry.dataSource.TableDataSource;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.JSONArray;
@@ -96,7 +97,7 @@ public class TopNQueryTest {
         TopNMetric metric = new SimpleMetric("count");
 
         DruidTopNQuery query = DruidTopNQuery.builder()
-                .dataSource("sample_data")
+                .dataSource(new TableDataSource("sample_data"))
                 .dimension(dimension)
                 .threshold(5)
                 .topNMetric(metric)
@@ -109,7 +110,10 @@ public class TopNQueryTest {
 
         String expectedJsonAsString = "{\n" +
                 "  \"queryType\": \"topN\",\n" +
-                "  \"dataSource\": \"sample_data\",\n" +
+                "  \"dataSource\": {\n" +
+                "    \"type\": \"table\",\n" +
+                "    \"name\": \"sample_data\"\n" +
+                "  },\n" +
                 "  \"dimension\": \"sample_dim\",\n" +
                 "  \"threshold\": 5,\n" +
                 "  \"metric\": \"count\",\n" +
@@ -182,7 +186,7 @@ public class TopNQueryTest {
         Granularity granularity = new SimpleGranularity(PredefinedGranularity.DAY);
 
         DruidTopNQuery query = DruidTopNQuery.builder()
-                .dataSource("sample_data")
+                .dataSource(new TableDataSource("sample_data"))
                 .intervals(Collections.singletonList(interval))
                 .granularity(granularity)
                 .dimension(dimension)
@@ -192,9 +196,13 @@ public class TopNQueryTest {
 
         String actualJson = objectMapper.writeValueAsString(query);
 
+        JSONObject dataSource = new JSONObject();
+        dataSource.put("type", "table");
+        dataSource.put("name", "sample_data");
+
         JSONObject expectedQuery = new JSONObject();
         expectedQuery.put("queryType", "topN");
-        expectedQuery.put("dataSource", "sample_data");
+        expectedQuery.put("dataSource", dataSource);
 
         JSONArray array = new JSONArray(Collections.singletonList("2013-08-31T00:00:00.000Z/2013-09-03T00:00:00.000Z"));
         expectedQuery.put("intervals", array);
@@ -225,7 +233,7 @@ public class TopNQueryTest {
                 .build();
 
         DruidTopNQuery query = DruidTopNQuery.builder()
-                .dataSource("sample_data")
+                .dataSource(new TableDataSource("sample_data"))
                 .intervals(Collections.singletonList(interval))
                 .granularity(granularity)
                 .filter(filter)
@@ -239,9 +247,13 @@ public class TopNQueryTest {
 
         String actualJson = objectMapper.writeValueAsString(query);
 
+        JSONObject dataSource = new JSONObject();
+        dataSource.put("type", "table");
+        dataSource.put("name", "sample_data");
+
         JSONObject expectedQuery = new JSONObject();
         expectedQuery.put("queryType", "topN");
-        expectedQuery.put("dataSource", "sample_data");
+        expectedQuery.put("dataSource", dataSource);
 
         JSONObject expectedFilter = new JSONObject();
         expectedFilter.put("type", "selector");
@@ -293,7 +305,7 @@ public class TopNQueryTest {
                 .build();
 
         DruidTopNQuery query1 = DruidTopNQuery.builder()
-                .dataSource("sample_data")
+                .dataSource(new TableDataSource("sample_data"))
                 .intervals(Collections.singletonList(interval))
                 .granularity(granularity)
                 .filter(filter)
@@ -306,7 +318,7 @@ public class TopNQueryTest {
                 .build();
 
         DruidTopNQuery query2 = DruidTopNQuery.builder()
-                .dataSource("sample_data")
+                .dataSource(new TableDataSource("sample_data"))
                 .intervals(Collections.singletonList(interval))
                 .granularity(granularity)
                 .filter(filter)
@@ -340,7 +352,7 @@ public class TopNQueryTest {
                 .build();
 
         DruidTopNQuery query1 = DruidTopNQuery.builder()
-                .dataSource("sample_data")
+                .dataSource(new TableDataSource("sample_data"))
                 .intervals(Collections.singletonList(interval))
                 .granularity(granularity)
                 .filter(filter)
@@ -353,7 +365,7 @@ public class TopNQueryTest {
                 .build();
 
         DruidTopNQuery query2 = DruidTopNQuery.builder()
-                .dataSource("sample_data")
+                .dataSource(new TableDataSource("sample_data"))
                 .intervals(Collections.singletonList(interval))
                 .granularity(granularity)
                 .filter(filter)
@@ -387,7 +399,7 @@ public class TopNQueryTest {
                 .build();
 
         DruidTopNQuery query1 = DruidTopNQuery.builder()
-                .dataSource("sample_data")
+                .dataSource(new TableDataSource("sample_data"))
                 .intervals(Collections.singletonList(interval))
                 .granularity(granularity)
                 .filter(filter)

--- a/src/test/java/in/zapr/druid/druidry/query/scan/DruidScanQueryTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/scan/DruidScanQueryTest.java
@@ -19,6 +19,7 @@ package in.zapr.druid.druidry.query.scan;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import in.zapr.druid.druidry.dataSource.TableDataSource;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.JSONException;
@@ -60,7 +61,7 @@ public class DruidScanQueryTest {
         DruidFilter filter = new SelectorFilter("dim1", "value1");
 
         DruidScanQuery query = DruidScanQuery.builder()
-                .dataSource("sample_datasource")
+                .dataSource(new TableDataSource("sample_datasource"))
                 .columns(searchDimensions)
                 .filter(filter)
                 .resultFormat(ResultFormat.LIST)
@@ -72,7 +73,10 @@ public class DruidScanQueryTest {
 
         String expectedJsonAsString = "{\n" +
                 "  \"queryType\": \"scan\",\n" +
-                "  \"dataSource\": \"sample_datasource\",\n" +
+                "  \"dataSource\": {\n" +
+                "    \"type\": \"table\",\n" +
+                "    \"name\": \"sample_datasource\"\n" +
+                "  },\n" +
                 "  \"columns\": [\n" +
                 "    \"dim1\",\n" +
                 "    \"dim2\"\n" +
@@ -107,13 +111,16 @@ public class DruidScanQueryTest {
         Interval interval = new Interval(startTime, endTime);
 
         DruidScanQuery query = DruidScanQuery.builder()
-                .dataSource("sample_datasource")
+                .dataSource(new TableDataSource("sample_datasource"))
                 .intervals(Collections.singletonList(interval))
                 .build();
 
         String expectedJsonAsString = "{\n" +
                 "  \"queryType\": \"scan\",\n" +
-                "  \"dataSource\": \"sample_datasource\",\n" +
+                "  \"dataSource\": {\n" +
+                "    \"type\": \"table\",\n" +
+                "    \"name\": \"sample_datasource\"\n" +
+                "  },\n" +
                 "  \"intervals\": [" +
                 "    \"2013-01-01T00:00:00.000Z/2013-01-03T00:00:00.000Z\"" +
                 "  ]" +
@@ -133,7 +140,7 @@ public class DruidScanQueryTest {
         Interval interval = new Interval(startTime, endTime);
 
         DruidScanQuery query = DruidScanQuery.builder()
-                .dataSource("sample_datasource")
+                .dataSource(new TableDataSource("sample_datasource"))
                 .intervals(Collections.singletonList(interval))
                 .limit(-1L)
                 .build();
@@ -150,7 +157,7 @@ public class DruidScanQueryTest {
         Interval interval = new Interval(startTime, endTime);
 
         DruidScanQuery query = DruidScanQuery.builder()
-                .dataSource("sample_datasource")
+                .dataSource(new TableDataSource("sample_datasource"))
                 .intervals(Collections.singletonList(interval))
                 .batchSize(-1)
                 .build();
@@ -173,7 +180,7 @@ public class DruidScanQueryTest {
         DruidFilter filter = new SelectorFilter("dim1", "value1");
 
         DruidScanQuery query = DruidScanQuery.builder()
-                .dataSource("sample_datasource")
+                .dataSource(new TableDataSource("sample_datasource"))
                 .columns(searchDimensions)
                 .filter(filter)
                 .resultFormat(ResultFormat.LIST)
@@ -185,7 +192,10 @@ public class DruidScanQueryTest {
 
         String expectedJsonAsString = "{\n" +
                 "  \"queryType\": \"scan\",\n" +
-                "  \"dataSource\": \"sample_datasource\",\n" +
+                "  \"dataSource\": {\n" +
+                "    \"type\": \"table\",\n" +
+                "    \"name\": \"sample_datasource\"\n" +
+                "  },\n" +
                 "  \"columns\": [\n" +
                 "],\n" +
                 "  \"filter\": {\n" +

--- a/src/test/java/in/zapr/druid/druidry/query/scan/DruidScanQueryTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/scan/DruidScanQueryTest.java
@@ -19,7 +19,6 @@ package in.zapr.druid.druidry.query.scan;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import in.zapr.druid.druidry.dataSource.TableDataSource;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.JSONException;
@@ -33,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 
 import in.zapr.druid.druidry.Interval;
+import in.zapr.druid.druidry.dataSource.TableDataSource;
 import in.zapr.druid.druidry.filter.DruidFilter;
 import in.zapr.druid.druidry.filter.SelectorFilter;
 

--- a/src/test/java/in/zapr/druid/druidry/query/search/DruidSearchQueryTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/search/DruidSearchQueryTest.java
@@ -19,7 +19,6 @@ package in.zapr.druid.druidry.query.search;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import in.zapr.druid.druidry.dataSource.TableDataSource;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.JSONException;
@@ -35,6 +34,7 @@ import java.util.List;
 import in.zapr.druid.druidry.Context;
 import in.zapr.druid.druidry.Interval;
 import in.zapr.druid.druidry.SortingOrder;
+import in.zapr.druid.druidry.dataSource.TableDataSource;
 import in.zapr.druid.druidry.dimension.DruidDimension;
 import in.zapr.druid.druidry.dimension.SimpleDimension;
 import in.zapr.druid.druidry.filter.DruidFilter;

--- a/src/test/java/in/zapr/druid/druidry/query/search/DruidSearchQueryTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/search/DruidSearchQueryTest.java
@@ -19,6 +19,7 @@ package in.zapr.druid.druidry.query.search;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import in.zapr.druid.druidry.dataSource.TableDataSource;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.JSONException;
@@ -66,7 +67,7 @@ public class DruidSearchQueryTest {
         Interval interval = new Interval(startTime, endTime);
 
         DruidSearchQuery query = DruidSearchQuery.builder()
-                .dataSource("sample_datasource")
+                .dataSource(new TableDataSource("sample_datasource"))
                 .granularity(new SimpleGranularity(PredefinedGranularity.DAY))
                 .searchDimensions(searchDimensions)
                 .query(searchQuerySpec)
@@ -76,7 +77,10 @@ public class DruidSearchQueryTest {
 
         String expectedJsonAsString = "{\n" +
                 "  \"queryType\": \"search\",\n" +
-                "  \"dataSource\": \"sample_datasource\",\n" +
+                "  \"dataSource\": {\n" +
+                "    \"type\": \"table\",\n" +
+                "    \"name\": \"sample_datasource\"\n" +
+                "  },\n" +
                 "  \"granularity\": \"day\",\n" +
                 "  \"searchDimensions\": [\n" +
                 "    \"dim1\",\n" +
@@ -110,7 +114,7 @@ public class DruidSearchQueryTest {
         Interval interval = new Interval(startTime, endTime);
 
         DruidSearchQuery query = DruidSearchQuery.builder()
-                .dataSource("sample_datasource")
+                .dataSource(new TableDataSource("sample_datasource"))
                 .granularity(new SimpleGranularity(PredefinedGranularity.DAY))
                 .query(searchQuerySpec)
                 .intervals(Collections.singletonList(interval))
@@ -118,7 +122,10 @@ public class DruidSearchQueryTest {
 
         String expectedJsonAsString = "{\n" +
                 "  \"queryType\": \"search\",\n" +
-                "  \"dataSource\": \"sample_datasource\",\n" +
+                "  \"dataSource\": {\n" +
+                "    \"type\": \"table\",\n" +
+                "    \"name\": \"sample_datasource\"\n" +
+                "  },\n" +
                 "  \"granularity\": \"day\",\n" +
                 "  \"query\": {\n" +
                 "    \"type\": \"insensitive_contains\",\n" +
@@ -154,7 +161,7 @@ public class DruidSearchQueryTest {
                 .build();
 
         DruidSearchQuery query = DruidSearchQuery.builder()
-                .dataSource("sample_datasource")
+                .dataSource(new TableDataSource("sample_datasource"))
                 .granularity(new SimpleGranularity(PredefinedGranularity.DAY))
                 .filter(druidFilter)
                 .limit(16)
@@ -167,7 +174,10 @@ public class DruidSearchQueryTest {
 
         String expectedJsonAsString = "{\n" +
                 "  \"queryType\": \"search\",\n" +
-                "  \"dataSource\": \"sample_datasource\",\n" +
+                "  \"dataSource\": {\n" +
+                "    \"type\": \"table\",\n" +
+                "    \"name\": \"sample_datasource\"\n" +
+                "  },\n" +
                 "  \"granularity\": \"day\",\n" +
                 "  \"filter\": {\n" +
                 "        \"type\": \"selector\",\n" +

--- a/src/test/java/in/zapr/druid/druidry/query/select/DruidSelectQueryTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/select/DruidSelectQueryTest.java
@@ -19,7 +19,6 @@ package in.zapr.druid.druidry.query.select;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import in.zapr.druid.druidry.dataSource.TableDataSource;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.JSONException;
@@ -32,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 
 import in.zapr.druid.druidry.Interval;
+import in.zapr.druid.druidry.dataSource.TableDataSource;
 import in.zapr.druid.druidry.granularity.Granularity;
 import in.zapr.druid.druidry.granularity.PredefinedGranularity;
 import in.zapr.druid.druidry.granularity.SimpleGranularity;

--- a/src/test/java/in/zapr/druid/druidry/query/select/DruidSelectQueryTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/select/DruidSelectQueryTest.java
@@ -19,6 +19,7 @@ package in.zapr.druid.druidry.query.select;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import in.zapr.druid.druidry.dataSource.TableDataSource;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.JSONException;
@@ -57,7 +58,7 @@ public class DruidSelectQueryTest {
         Granularity granularity = new SimpleGranularity(PredefinedGranularity.ALL);
 
         DruidSelectQuery query = DruidSelectQuery.builder()
-                .dataSource("wikipedia")
+                .dataSource(new TableDataSource("wikipedia"))
                 .descending(false)
                 .granularity(granularity)
                 .intervals(Collections.singletonList(interval))
@@ -66,7 +67,10 @@ public class DruidSelectQueryTest {
 
         String expectedJsonAsString = "{\n" +
                 "  \"queryType\": \"select\",\n" +
-                "  \"dataSource\": \"wikipedia\",\n" +
+                "  \"dataSource\": {\n" +
+                "    \"type\": \"table\",\n" +
+                "    \"name\": \"wikipedia\"\n" +
+                "  },\n" +
                 "  \"intervals\": [" +
                 "    \"2013-01-01T00:00:00.000Z/2013-01-02T00:00:00.000Z\"" +
                 "  ]," +
@@ -97,7 +101,7 @@ public class DruidSelectQueryTest {
         Granularity granularity = new SimpleGranularity(PredefinedGranularity.ALL);
 
         DruidSelectQuery query = DruidSelectQuery.builder()
-                .dataSource("wikipedia")
+                .dataSource(new TableDataSource("wikipedia"))
                 .descending(false)
                 .granularity(granularity)
                 .intervals(Collections.singletonList(interval))
@@ -106,7 +110,10 @@ public class DruidSelectQueryTest {
 
         String expectedJsonAsString = "{\n" +
                 "  \"queryType\": \"select\",\n" +
-                "  \"dataSource\": \"wikipedia\",\n" +
+                "  \"dataSource\": {\n" +
+                "    \"type\": \"table\",\n" +
+                "    \"name\": \"wikipedia\"\n" +
+                "  },\n" +
                 "  \"intervals\": [" +
                 "    \"2013-01-01T00:00:00.000Z/2013-01-02T00:00:00.000Z\"" +
                 "  ]," +
@@ -152,7 +159,7 @@ public class DruidSelectQueryTest {
         Granularity granularity = new SimpleGranularity(PredefinedGranularity.ALL);
 
         DruidSelectQuery.builder()
-                .dataSource("dataSource")
+                .dataSource(new TableDataSource("dataSource"))
                 .descending(false)
                 .granularity(granularity)
                 .pagingSpec(pagingSpec)
@@ -170,7 +177,7 @@ public class DruidSelectQueryTest {
         Granularity granularity = new SimpleGranularity(PredefinedGranularity.ALL);
 
         DruidSelectQuery.builder()
-                .dataSource("dataSource")
+                .dataSource(new TableDataSource("dataSource"))
                 .descending(false)
                 .granularity(granularity)
                 .intervals(Collections.singletonList(interval))


### PR DESCRIPTION
Hello. This pull request includes support for all types of datasource (table, union, query). It's nice feature for support subquery as datasource. I understand, this change breaking backward compatibility, but it's very important feature. May be adding this change in 3.0 release is better.