### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.9.9.2</jackson.version>
         <jodatime.version>2.9.7</jodatime.version>
         <lombok.version>1.16.14</lombok.version>
         <testng.version>6.11</testng.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jackson.version>2.9.9.2</jackson.version>
+        <jackson.databind.version>2.9.9.2</jackson.databind.version>
+        <jackson.datatype.version>2.9.9</jackson.datatype.version>
         <jodatime.version>2.9.7</jodatime.version>
         <lombok.version>1.16.14</lombok.version>
         <testng.version>6.11</testng.version>
@@ -38,13 +39,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.datatype.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION

Known moderate severity security vulnerability detected in com.fasterxml.jackson.core:jackson-databind < 2.9.9.2 defined in pom.xml.
--
pom.xml update suggested: com.fasterxml.jackson.core:jackson-databind ~> 2.9.9.2.

