### PR TITLE
Correct a variable's name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ DruidConfiguration config =  DruidConfiguration
                .endpoint("druid/v2/")
                .build();
 
-DruidClient client = new DruidJerseyClient(druidConfiguration);
+DruidClient client = new DruidJerseyClient(config);
 client.connect();
 List<DruidResponse> responses = client.query(query, DruidResponse.class);
 client.close();


### PR DESCRIPTION
In the example doesn't exist a variable with the name of "druidConfiguration". I corrected the name to "config".