### PR TITLE
Allowing filter of null as dimension value

### DIFF
--- a/src/main/java/in/zapr/druid/druidry/filter/SelectorFilter.java
+++ b/src/main/java/in/zapr/druid/druidry/filter/SelectorFilter.java
@@ -16,6 +16,8 @@
 
 package in.zapr.druid.druidry.filter;
 
+import java.util.Optional;
+
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
@@ -34,18 +36,28 @@ public class SelectorFilter extends DruidFilter {
         this.dimension = dimension;
     }
 
+    @Deprecated
     public SelectorFilter(@NonNull String dimension, String value) {
         this(dimension);
         this.value = value;
     }
 
+    @Deprecated
     public SelectorFilter(@NonNull String dimension, Integer value) {
         this(dimension);
         this.value = value;
     }
 
+    @Deprecated
     public SelectorFilter(@NonNull String dimension, Long value) {
         this(dimension);
         this.value = value;
+    }
+
+    public SelectorFilter(@NonNull String dimension, Optional<Object> value) {
+        this(dimension);
+        if (value.isPresent()) {
+            this.value = value.get();
+        }
     }
 }

--- a/src/main/java/in/zapr/druid/druidry/filter/SelectorFilter.java
+++ b/src/main/java/in/zapr/druid/druidry/filter/SelectorFilter.java
@@ -36,19 +36,16 @@ public class SelectorFilter extends DruidFilter {
         this.dimension = dimension;
     }
 
-    @Deprecated
     public SelectorFilter(@NonNull String dimension, String value) {
         this(dimension);
         this.value = value;
     }
 
-    @Deprecated
     public SelectorFilter(@NonNull String dimension, Integer value) {
         this(dimension);
         this.value = value;
     }
 
-    @Deprecated
     public SelectorFilter(@NonNull String dimension, Long value) {
         this(dimension);
         this.value = value;

--- a/src/test/java/in/zapr/druid/druidry/filter/SelectorFilterTest.java
+++ b/src/test/java/in/zapr/druid/druidry/filter/SelectorFilterTest.java
@@ -26,6 +26,8 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Optional;
+
 public class SelectorFilterTest {
 
     private static ObjectMapper objectMapper;
@@ -68,6 +70,58 @@ public class SelectorFilterTest {
         jsonObject.put("type", "selector");
         jsonObject.put("dimension", "Hello");
         jsonObject.put("value", 1488498926000L);
+
+        String actualJSON = objectMapper.writeValueAsString(filter);
+        String expectedJSON = jsonObject.toString();
+        JSONAssert.assertEquals(expectedJSON, actualJSON, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    public void testOptionalWithStringField() throws JSONException, JsonProcessingException {
+        SelectorFilter filter = new SelectorFilter("Hello", Optional.ofNullable("World"));
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("type", "selector");
+        jsonObject.put("dimension", "Hello");
+        jsonObject.put("value", "World");
+
+        String actualJSON = objectMapper.writeValueAsString(filter);
+        String expectedJSON = jsonObject.toString();
+        JSONAssert.assertEquals(expectedJSON, actualJSON, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    public void testOptionalWithIntegerField() throws JSONException, JsonProcessingException {
+        SelectorFilter filter = new SelectorFilter("Hello", Optional.ofNullable(5));
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("type", "selector");
+        jsonObject.put("dimension", "Hello");
+        jsonObject.put("value", 5);
+
+        String actualJSON = objectMapper.writeValueAsString(filter);
+        String expectedJSON = jsonObject.toString();
+        JSONAssert.assertEquals(expectedJSON, actualJSON, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    public void testOptionalWithLongField() throws JSONException, JsonProcessingException {
+        SelectorFilter filter = new SelectorFilter("Hello", Optional.ofNullable(1488498926000L));
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("type", "selector");
+        jsonObject.put("dimension", "Hello");
+        jsonObject.put("value", 1488498926000L);
+
+        String actualJSON = objectMapper.writeValueAsString(filter);
+        String expectedJSON = jsonObject.toString();
+        JSONAssert.assertEquals(expectedJSON, actualJSON, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    public void testOptionalWithNullField() throws JSONException, JsonProcessingException {
+        SelectorFilter filter = new SelectorFilter("Hello", Optional.ofNullable(null));
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("type", "selector");
+        jsonObject.put("dimension", "Hello");
+        jsonObject.putOpt("value", JSONObject.NULL);
 
         String actualJSON = objectMapper.writeValueAsString(filter);
         String expectedJSON = jsonObject.toString();


### PR DESCRIPTION
Introducing new constructor with `Optional<T>` argument.

This will help in filtering out `null` values of dimension :
`{ "type" : "selector", "dimension" : "name", "value" : null }`

Fixing issue #100 