### PR TITLE
Revert 2caddd9 and update javadoc plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.4</version>
+                        <version>3.1.1</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
Build on master is failing as travis in using java 11.0.2 to build with following error :
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.4:jar (attach-javadocs) on project druidry: MavenReportException: Error while generating Javadoc: 
2628[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
2629[ERROR] 
2630[ERROR] Command line was: /usr/local/lib/jvm/openjdk11/bin/javadoc @options @packages
```
It's a known issue in `maven-javadoc-plugin`. 

**Refer** : 
https://bugs.openjdk.java.net/browse/JDK-8212233
https://issues.apache.org/jira/browse/MJAVADOC-562