### PR TITLE
Upgrading maven-javadoc-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>in.zapr.druid</groupId>
     <artifactId>druidry</artifactId>
-    <version>3.1-SNAPSHOT</version>
+    <version>3.0</version>
 
     <name>Druidry - Druid Java Client</name>
     <description>Druidry is an open-source Java based utility library which supports creating

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>in.zapr.druid</groupId>
     <artifactId>druidry</artifactId>
-    <version>3.0</version>
+    <version>3.1-SNAPSHOT</version>
 
     <name>Druidry - Druid Java Client</name>
     <description>Druidry is an open-source Java based utility library which supports creating

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>in.zapr.druid</groupId>
     <artifactId>druidry</artifactId>
-    <version>2.15-SNAPSHOT</version>
+    <version>3.0</version>
 
     <name>Druidry - Druid Java Client</name>
     <description>Druidry is an open-source Java based utility library which supports creating


### PR DESCRIPTION
Upgraded `maven-javadoc-plugin` version due to know issue [JDK-8212233](https://bugs.openjdk.java.net/browse/JDK-8212233) and fix release [MJAVADOC-562](https://issues.apache.org/jira/browse/MJAVADOC-562)