### PR TITLE
Adding source in javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>3.1.1</version>
+                        <configuration>
+                            <source>8</source>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
Failing even after plugin version upgrade, adding source in javadoc plugin configuration.
After suggestion from here : https://github.com/joel-costigliola/assertj-core/issues/1403#issuecomment-500100254