### PR TITLE
Adding source in javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>in.zapr.druid</groupId>
     <artifactId>druidry</artifactId>
-    <version>3.1-SNAPSHOT</version>
+    <version>3.0</version>
 
     <name>Druidry - Druid Java Client</name>
     <description>Druidry is an open-source Java based utility library which supports creating


### PR DESCRIPTION
Failing even after plugin version upgrade, adding source in javadoc plugin configuration.
After suggestion from here :https://github.com/joel-costigliola/assertj-core/issues/1403#issuecomment-500100254