### PR TITLE
Added expression support to some aggregators

### DIFF
--- a/src/main/java/in/zapr/druid/druidry/aggregator/DoubleMaxAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/aggregator/DoubleMaxAggregator.java
@@ -42,5 +42,17 @@ public class DoubleMaxAggregator extends DruidAggregator {
         this.name = name;
         this.fieldName = fieldName;
     }
+    @Builder
+    private DoubleMaxAggregator(@NonNull String name, String fieldName, String expression) {
 
+        this.type = DOUBLE_MAX_TYPE_AGGREGATOR;
+        this.name = name;
+        this.fieldName = fieldName;
+        this.expression = expression;
+
+        Preconditions.checkArgument(
+                fieldName == null ^ expression == null,
+                "Must have a valid, non-null fieldName or expression"
+        );
+    }
 }

--- a/src/main/java/in/zapr/druid/druidry/aggregator/DoubleMaxAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/aggregator/DoubleMaxAggregator.java
@@ -19,17 +19,28 @@ package in.zapr.druid.druidry.aggregator;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public class DoubleMaxAggregator extends DruidAggregator {
 
     private static final String DOUBLE_MAX_TYPE_AGGREGATOR = "doubleMax";
+
     private String fieldName;
+
+    @Setter
+    private String expression;
+
+    public DoubleMaxAggregator(@NonNull String name) {
+        this.type = DOUBLE_MAX_TYPE_AGGREGATOR;
+        this.name = name;
+    }
 
     public DoubleMaxAggregator(@NonNull String name, @NonNull String fieldName) {
         this.type = DOUBLE_MAX_TYPE_AGGREGATOR;
         this.name = name;
         this.fieldName = fieldName;
     }
+
 }

--- a/src/main/java/in/zapr/druid/druidry/aggregator/DoubleMaxAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/aggregator/DoubleMaxAggregator.java
@@ -23,6 +23,7 @@ import lombok.Setter;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class DoubleMaxAggregator extends DruidAggregator {
 
     private static final String DOUBLE_MAX_TYPE_AGGREGATOR = "doubleMax";

--- a/src/main/java/in/zapr/druid/druidry/aggregator/DoubleMaxAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/aggregator/DoubleMaxAggregator.java
@@ -16,10 +16,14 @@
 
 package in.zapr.druid.druidry.aggregator;
 
+import com.google.common.base.Preconditions;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.Setter;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
@@ -29,14 +33,7 @@ public class DoubleMaxAggregator extends DruidAggregator {
     private static final String DOUBLE_MAX_TYPE_AGGREGATOR = "doubleMax";
 
     private String fieldName;
-
-    @Setter
     private String expression;
-
-    public DoubleMaxAggregator(@NonNull String name) {
-        this.type = DOUBLE_MAX_TYPE_AGGREGATOR;
-        this.name = name;
-    }
 
     @Deprecated
     public DoubleMaxAggregator(@NonNull String name, @NonNull String fieldName) {
@@ -44,17 +41,18 @@ public class DoubleMaxAggregator extends DruidAggregator {
         this.name = name;
         this.fieldName = fieldName;
     }
+
     @Builder
     private DoubleMaxAggregator(@NonNull String name, String fieldName, String expression) {
-
         this.type = DOUBLE_MAX_TYPE_AGGREGATOR;
         this.name = name;
         this.fieldName = fieldName;
         this.expression = expression;
 
         Preconditions.checkArgument(
-                fieldName == null ^ expression == null,
-                "Must have a valid, non-null fieldName or expression"
+            fieldName == null ^ expression == null,
+            "Must have a valid, non-null fieldName or expression"
         );
     }
+
 }

--- a/src/main/java/in/zapr/druid/druidry/aggregator/DoubleMaxAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/aggregator/DoubleMaxAggregator.java
@@ -38,6 +38,7 @@ public class DoubleMaxAggregator extends DruidAggregator {
         this.name = name;
     }
 
+    @Deprecated
     public DoubleMaxAggregator(@NonNull String name, @NonNull String fieldName) {
         this.type = DOUBLE_MAX_TYPE_AGGREGATOR;
         this.name = name;

--- a/src/main/java/in/zapr/druid/druidry/aggregator/DoubleMinAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/aggregator/DoubleMinAggregator.java
@@ -16,31 +16,43 @@
 
 package in.zapr.druid.druidry.aggregator;
 
+import com.google.common.base.Preconditions;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.Setter;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class DoubleMinAggregator extends DruidAggregator {
 
     private static final String DOUBLE_MIN_TYPE_AGGREGATOR = "doubleMin";
 
     private String fieldName;
-
-    @Setter
     private String expression;
 
-    public DoubleMinAggregator(@NonNull String name) {
-        this.type = DOUBLE_MIN_TYPE_AGGREGATOR;
-        this.name = name;
-    }
-
+    @Deprecated
     public DoubleMinAggregator(@NonNull String name, @NonNull String fieldName) {
         this.type = DOUBLE_MIN_TYPE_AGGREGATOR;
         this.name = name;
         this.fieldName = fieldName;
+    }
+
+    @Builder
+    private DoubleMinAggregator(@NonNull String name, String fieldName, String expression) {
+        this.type = DOUBLE_MIN_TYPE_AGGREGATOR;
+        this.name = name;
+        this.fieldName = fieldName;
+        this.expression = expression;
+
+        Preconditions.checkArgument(
+            fieldName == null ^ expression == null,
+            "Must have a valid, non-null fieldName or expression"
+        );
     }
 
 }

--- a/src/main/java/in/zapr/druid/druidry/aggregator/DoubleMinAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/aggregator/DoubleMinAggregator.java
@@ -19,17 +19,28 @@ package in.zapr.druid.druidry.aggregator;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public class DoubleMinAggregator extends DruidAggregator {
 
     private static final String DOUBLE_MIN_TYPE_AGGREGATOR = "doubleMin";
+
     private String fieldName;
+
+    @Setter
+    private String expression;
+
+    public DoubleMinAggregator(@NonNull String name) {
+        this.type = DOUBLE_MIN_TYPE_AGGREGATOR;
+        this.name = name;
+    }
 
     public DoubleMinAggregator(@NonNull String name, @NonNull String fieldName) {
         this.type = DOUBLE_MIN_TYPE_AGGREGATOR;
         this.name = name;
         this.fieldName = fieldName;
     }
+
 }

--- a/src/main/java/in/zapr/druid/druidry/aggregator/DoubleSumAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/aggregator/DoubleSumAggregator.java
@@ -19,17 +19,28 @@ package in.zapr.druid.druidry.aggregator;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public class DoubleSumAggregator extends DruidAggregator {
 
     private static final String DOUBLE_SUM_TYPE_AGGREGATOR = "doubleSum";
+
     private String fieldName;
+
+    @Setter
+    private String expression;
+
+    public DoubleSumAggregator(@NonNull String name) {
+        this.type = DOUBLE_SUM_TYPE_AGGREGATOR;
+        this.name = name;
+    }
 
     public DoubleSumAggregator(@NonNull String name, @NonNull String fieldName) {
         this.type = DOUBLE_SUM_TYPE_AGGREGATOR;
         this.name = name;
         this.fieldName = fieldName;
     }
+
 }

--- a/src/main/java/in/zapr/druid/druidry/aggregator/DoubleSumAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/aggregator/DoubleSumAggregator.java
@@ -16,31 +16,43 @@
 
 package in.zapr.druid.druidry.aggregator;
 
+import com.google.common.base.Preconditions;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.Setter;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class DoubleSumAggregator extends DruidAggregator {
 
     private static final String DOUBLE_SUM_TYPE_AGGREGATOR = "doubleSum";
 
     private String fieldName;
-
-    @Setter
     private String expression;
 
-    public DoubleSumAggregator(@NonNull String name) {
-        this.type = DOUBLE_SUM_TYPE_AGGREGATOR;
-        this.name = name;
-    }
-
+    @Deprecated
     public DoubleSumAggregator(@NonNull String name, @NonNull String fieldName) {
         this.type = DOUBLE_SUM_TYPE_AGGREGATOR;
         this.name = name;
         this.fieldName = fieldName;
+    }
+
+    @Builder
+    private DoubleSumAggregator(@NonNull String name, String fieldName, String expression) {
+        this.type = DOUBLE_SUM_TYPE_AGGREGATOR;
+        this.name = name;
+        this.fieldName = fieldName;
+        this.expression = expression;
+
+        Preconditions.checkArgument(
+            fieldName == null ^ expression == null,
+            "Must have a valid, non-null fieldName or expression"
+        );
     }
 
 }

--- a/src/main/java/in/zapr/druid/druidry/aggregator/LongMaxAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/aggregator/LongMaxAggregator.java
@@ -19,16 +19,28 @@ package in.zapr.druid.druidry.aggregator;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public class LongMaxAggregator extends DruidAggregator {
+
     private static final String LONG_MAX_TYPE_AGGREGATOR = "longMax";
+
     private String fieldName;
+
+    @Setter
+    private String expression;
+
+    public LongMaxAggregator(@NonNull String name) {
+        this.type = LONG_MAX_TYPE_AGGREGATOR;
+        this.name = name;
+    }
 
     public LongMaxAggregator(@NonNull String name, @NonNull String fieldName) {
         this.type = LONG_MAX_TYPE_AGGREGATOR;
         this.name = name;
         this.fieldName = fieldName;
     }
+
 }

--- a/src/main/java/in/zapr/druid/druidry/aggregator/LongMaxAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/aggregator/LongMaxAggregator.java
@@ -16,31 +16,43 @@
 
 package in.zapr.druid.druidry.aggregator;
 
+import com.google.common.base.Preconditions;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.Setter;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class LongMaxAggregator extends DruidAggregator {
 
     private static final String LONG_MAX_TYPE_AGGREGATOR = "longMax";
 
     private String fieldName;
-
-    @Setter
     private String expression;
 
-    public LongMaxAggregator(@NonNull String name) {
-        this.type = LONG_MAX_TYPE_AGGREGATOR;
-        this.name = name;
-    }
-
+    @Deprecated
     public LongMaxAggregator(@NonNull String name, @NonNull String fieldName) {
         this.type = LONG_MAX_TYPE_AGGREGATOR;
         this.name = name;
         this.fieldName = fieldName;
+    }
+
+    @Builder
+    private LongMaxAggregator(@NonNull String name, String fieldName, String expression) {
+        this.type = LONG_MAX_TYPE_AGGREGATOR;
+        this.name = name;
+        this.fieldName = fieldName;
+        this.expression = expression;
+
+        Preconditions.checkArgument(
+            fieldName == null ^ expression == null,
+            "Must have a valid, non-null fieldName or expression"
+        );
     }
 
 }

--- a/src/main/java/in/zapr/druid/druidry/aggregator/LongMinAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/aggregator/LongMinAggregator.java
@@ -19,17 +19,28 @@ package in.zapr.druid.druidry.aggregator;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public class LongMinAggregator extends DruidAggregator {
 
     private static final String LONG_MIN_TYPE_AGGREGATOR = "longMin";
+
     private String fieldName;
+
+    @Setter
+    private String expression;
+
+    public LongMinAggregator(@NonNull String name) {
+        this.type = LONG_MIN_TYPE_AGGREGATOR;
+        this.name = name;
+    }
 
     public LongMinAggregator(@NonNull String name, @NonNull String fieldName) {
         this.type = LONG_MIN_TYPE_AGGREGATOR;
         this.name = name;
         this.fieldName = fieldName;
     }
+
 }

--- a/src/main/java/in/zapr/druid/druidry/aggregator/LongMinAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/aggregator/LongMinAggregator.java
@@ -16,31 +16,43 @@
 
 package in.zapr.druid.druidry.aggregator;
 
+import com.google.common.base.Preconditions;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.Setter;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class LongMinAggregator extends DruidAggregator {
 
     private static final String LONG_MIN_TYPE_AGGREGATOR = "longMin";
 
     private String fieldName;
-
-    @Setter
     private String expression;
 
-    public LongMinAggregator(@NonNull String name) {
-        this.type = LONG_MIN_TYPE_AGGREGATOR;
-        this.name = name;
-    }
-
+    @Deprecated
     public LongMinAggregator(@NonNull String name, @NonNull String fieldName) {
         this.type = LONG_MIN_TYPE_AGGREGATOR;
         this.name = name;
         this.fieldName = fieldName;
+    }
+
+    @Builder
+    private LongMinAggregator(@NonNull String name, String fieldName, String expression) {
+        this.type = LONG_MIN_TYPE_AGGREGATOR;
+        this.name = name;
+        this.fieldName = fieldName;
+        this.expression = expression;
+
+        Preconditions.checkArgument(
+            fieldName == null ^ expression == null,
+            "Must have a valid, non-null fieldName or expression"
+        );
     }
 
 }

--- a/src/main/java/in/zapr/druid/druidry/aggregator/LongSumAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/aggregator/LongSumAggregator.java
@@ -16,31 +16,43 @@
 
 package in.zapr.druid.druidry.aggregator;
 
+import com.google.common.base.Preconditions;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.Setter;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class LongSumAggregator extends DruidAggregator {
 
     private static final String LONGSUM_TYPE_AGGREGATOR = "longSum";
 
     private String fieldName;
-
-    @Setter
     private String expression;
 
-    public LongSumAggregator(@NonNull String name) {
-        this.type = LONGSUM_TYPE_AGGREGATOR;
-        this.name = name;
-    }
-
+    @Deprecated
     public LongSumAggregator(@NonNull String name, @NonNull String fieldName) {
         this.type = LONGSUM_TYPE_AGGREGATOR;
         this.name = name;
         this.fieldName = fieldName;
+    }
+
+    @Builder
+    private LongSumAggregator(@NonNull String name, String fieldName, String expression) {
+        this.type = LONGSUM_TYPE_AGGREGATOR;
+        this.name = name;
+        this.fieldName = fieldName;
+        this.expression = expression;
+
+        Preconditions.checkArgument(
+            fieldName == null ^ expression == null,
+            "Must have a valid, non-null fieldName or expression"
+        );
     }
 
 }

--- a/src/main/java/in/zapr/druid/druidry/aggregator/LongSumAggregator.java
+++ b/src/main/java/in/zapr/druid/druidry/aggregator/LongSumAggregator.java
@@ -19,17 +19,28 @@ package in.zapr.druid.druidry.aggregator;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public class LongSumAggregator extends DruidAggregator {
 
     private static final String LONGSUM_TYPE_AGGREGATOR = "longSum";
+
     private String fieldName;
+
+    @Setter
+    private String expression;
+
+    public LongSumAggregator(@NonNull String name) {
+        this.type = LONGSUM_TYPE_AGGREGATOR;
+        this.name = name;
+    }
 
     public LongSumAggregator(@NonNull String name, @NonNull String fieldName) {
         this.type = LONGSUM_TYPE_AGGREGATOR;
         this.name = name;
         this.fieldName = fieldName;
     }
+
 }

--- a/src/test/java/in/zapr/druid/druidry/aggregator/DoubleMaxAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/DoubleMaxAggregatorTest.java
@@ -40,13 +40,10 @@ public class DoubleMaxAggregatorTest {
     }
 
     @Test
-    public void testAllButExpression() throws JSONException, JsonProcessingException {
+    public void testAllFields() throws JsonProcessingException, JSONException {
 
-        DoubleMaxAggregator doubleMaxAggregator =
-            DoubleMaxAggregator.builder()
-                .name("CarpeDiem")
-                .fieldName("Hey")
-                .build();
+        DoubleMaxAggregator doubleMaxAggregator = new DoubleMaxAggregator("CarpeDiem",
+                "Hey");
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "doubleMax");

--- a/src/test/java/in/zapr/druid/druidry/aggregator/DoubleMaxAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/DoubleMaxAggregatorTest.java
@@ -45,10 +45,13 @@ public class DoubleMaxAggregatorTest {
         DoubleMaxAggregator doubleMaxAggregator = new DoubleMaxAggregator("CarpeDiem",
                 "Hey");
 
+        doubleMaxAggregator.setExpression("(\"foo\" / \"bar\")");
+
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "doubleMax");
         jsonObject.put("name", "CarpeDiem");
         jsonObject.put("fieldName", "Hey");
+        jsonObject.put("expression", "(\"foo\" / \"bar\")");
 
         String actualJSON = objectMapper.writeValueAsString(doubleMaxAggregator);
         String expectedJSON = jsonObject.toString();
@@ -72,7 +75,16 @@ public class DoubleMaxAggregatorTest {
         DoubleMaxAggregator aggregator1 = new DoubleMaxAggregator("name", "field");
         DoubleMaxAggregator aggregator2 = new DoubleMaxAggregator("name", "field");
 
+        DoubleMaxAggregator aggregator3 = new DoubleMaxAggregator("name", "field");
+
+        aggregator3.setExpression("(\"foo\" / \"bar\")");
+
+        DoubleMaxAggregator aggregator4 = new DoubleMaxAggregator("name", "field");
+
+        aggregator4.setExpression("(\"foo\" / \"bar\")");
+
         Assert.assertEquals(aggregator1, aggregator2);
+        Assert.assertEquals(aggregator3, aggregator4);
     }
 
     @Test
@@ -80,7 +92,16 @@ public class DoubleMaxAggregatorTest {
         DoubleMaxAggregator aggregator1 = new DoubleMaxAggregator("name", "field");
         DoubleMaxAggregator aggregator2 = new DoubleMaxAggregator("name1", "field1");
 
+        DoubleMaxAggregator aggregator3 = new DoubleMaxAggregator("name", "field");
+
+        aggregator3.setExpression("(\"foo\" / \"bar\")");
+
+        DoubleMaxAggregator aggregator4 = new DoubleMaxAggregator("name", "field");
+
+        aggregator4.setExpression("(\"foo\" / \"baz\")");
+
         Assert.assertNotEquals(aggregator1, aggregator2);
+        Assert.assertNotEquals(aggregator3, aggregator4);
     }
 
     @Test

--- a/src/test/java/in/zapr/druid/druidry/aggregator/DoubleMaxAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/DoubleMaxAggregatorTest.java
@@ -40,17 +40,36 @@ public class DoubleMaxAggregatorTest {
     }
 
     @Test
-    public void testAllFields() throws JsonProcessingException, JSONException {
+    public void testAllButExpression() throws JSONException, JsonProcessingException {
 
-        DoubleMaxAggregator doubleMaxAggregator = new DoubleMaxAggregator("CarpeDiem",
-                "Hey");
-
-        doubleMaxAggregator.setExpression("(\"foo\" / \"bar\")");
+        DoubleMaxAggregator doubleMaxAggregator =
+            DoubleMaxAggregator.builder()
+                .name("CarpeDiem")
+                .fieldName("Hey")
+                .build();
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "doubleMax");
         jsonObject.put("name", "CarpeDiem");
         jsonObject.put("fieldName", "Hey");
+
+        String actualJSON = objectMapper.writeValueAsString(doubleMaxAggregator);
+        String expectedJSON = jsonObject.toString();
+        JSONAssert.assertEquals(expectedJSON, actualJSON, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    public void testAllButFieldName() throws JSONException, JsonProcessingException {
+
+        DoubleMaxAggregator doubleMaxAggregator =
+            DoubleMaxAggregator.builder()
+                .name("CarpeDiem")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("type", "doubleMax");
+        jsonObject.put("name", "CarpeDiem");
         jsonObject.put("expression", "(\"foo\" / \"bar\")");
 
         String actualJSON = objectMapper.writeValueAsString(doubleMaxAggregator);
@@ -61,27 +80,37 @@ public class DoubleMaxAggregatorTest {
     @Test(expectedExceptions = NullPointerException.class)
     public void testNullName() throws JsonProcessingException, JSONException {
 
-        DoubleMaxAggregator doubleMaxAggregator = new DoubleMaxAggregator(null, "Haha");
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void testNullFieldName() throws JsonProcessingException, JSONException {
-
-        DoubleMaxAggregator doubleMaxAggregator = new DoubleMaxAggregator("Name", null);
+        DoubleMaxAggregator doubleMaxAggregator =
+            DoubleMaxAggregator.builder()
+                .fieldName("Haha")
+                .build();
     }
 
     @Test
     public void testEqualsPositive() {
-        DoubleMaxAggregator aggregator1 = new DoubleMaxAggregator("name", "field");
-        DoubleMaxAggregator aggregator2 = new DoubleMaxAggregator("name", "field");
+        DoubleMaxAggregator aggregator1 =
+            DoubleMaxAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        DoubleMaxAggregator aggregator3 = new DoubleMaxAggregator("name", "field");
+        DoubleMaxAggregator aggregator2 =
+            DoubleMaxAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        aggregator3.setExpression("(\"foo\" / \"bar\")");
+        DoubleMaxAggregator aggregator3 =
+            DoubleMaxAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
-        DoubleMaxAggregator aggregator4 = new DoubleMaxAggregator("name", "field");
-
-        aggregator4.setExpression("(\"foo\" / \"bar\")");
+        DoubleMaxAggregator aggregator4 =
+            DoubleMaxAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
         Assert.assertEquals(aggregator1, aggregator2);
         Assert.assertEquals(aggregator3, aggregator4);
@@ -89,16 +118,29 @@ public class DoubleMaxAggregatorTest {
 
     @Test
     public void testEqualsNegative() {
-        DoubleMaxAggregator aggregator1 = new DoubleMaxAggregator("name", "field");
-        DoubleMaxAggregator aggregator2 = new DoubleMaxAggregator("name1", "field1");
+        DoubleMaxAggregator aggregator1 =
+            DoubleMaxAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        DoubleMaxAggregator aggregator3 = new DoubleMaxAggregator("name", "field");
+        DoubleMaxAggregator aggregator2 =
+            DoubleMaxAggregator.builder()
+                .name("name1")
+                .fieldName("field1")
+                .build();
 
-        aggregator3.setExpression("(\"foo\" / \"bar\")");
+        DoubleMaxAggregator aggregator3 =
+            DoubleMaxAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
-        DoubleMaxAggregator aggregator4 = new DoubleMaxAggregator("name", "field");
-
-        aggregator4.setExpression("(\"foo\" / \"baz\")");
+        DoubleMaxAggregator aggregator4 =
+            DoubleMaxAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"baz\")")
+                .build();
 
         Assert.assertNotEquals(aggregator1, aggregator2);
         Assert.assertNotEquals(aggregator3, aggregator4);
@@ -106,9 +148,15 @@ public class DoubleMaxAggregatorTest {
 
     @Test
     public void testEqualsWithAnotherSubClass() {
-        DoubleMaxAggregator aggregator1 = new DoubleMaxAggregator("name", "field");
+        DoubleMaxAggregator aggregator1 =
+            DoubleMaxAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
+
         CountAggregator aggregator2 = new CountAggregator("countAgg1");
 
         Assert.assertNotEquals(aggregator1, aggregator2);
     }
+
 }

--- a/src/test/java/in/zapr/druid/druidry/aggregator/DoubleMinAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/DoubleMinAggregatorTest.java
@@ -40,13 +40,10 @@ public class DoubleMinAggregatorTest {
     }
 
     @Test
-    public void testAllFieldsButExpression() throws JSONException, JsonProcessingException {
+    public void testAllFields() throws JsonProcessingException, JSONException {
 
-        DoubleMinAggregator doubleMinAggregator =
-            DoubleMinAggregator.builder()
-                .name("CarpeDiem")
-                .fieldName("Hey")
-                .build();
+        DoubleMinAggregator doubleMinAggregator = new DoubleMinAggregator("CarpeDiem",
+                "Hey");
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "doubleMin");

--- a/src/test/java/in/zapr/druid/druidry/aggregator/DoubleMinAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/DoubleMinAggregatorTest.java
@@ -40,17 +40,36 @@ public class DoubleMinAggregatorTest {
     }
 
     @Test
-    public void testAllFields() throws JsonProcessingException, JSONException {
+    public void testAllFieldsButExpression() throws JSONException, JsonProcessingException {
 
-        DoubleMinAggregator doubleMinAggregator = new DoubleMinAggregator("CarpeDiem",
-                "Hey");
-
-        doubleMinAggregator.setExpression("(\"foo\" / \"bar\")");
+        DoubleMinAggregator doubleMinAggregator =
+            DoubleMinAggregator.builder()
+                .name("CarpeDiem")
+                .fieldName("Hey")
+                .build();
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "doubleMin");
         jsonObject.put("name", "CarpeDiem");
         jsonObject.put("fieldName", "Hey");
+
+        String actualJSON = objectMapper.writeValueAsString(doubleMinAggregator);
+        String expectedJSON = jsonObject.toString();
+        JSONAssert.assertEquals(expectedJSON, actualJSON, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    public void testAllFieldsButFieldName() throws JSONException, JsonProcessingException {
+
+        DoubleMinAggregator doubleMinAggregator =
+            DoubleMinAggregator.builder()
+                .name("CarpeDiem")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("type", "doubleMin");
+        jsonObject.put("name", "CarpeDiem");
         jsonObject.put("expression", "(\"foo\" / \"bar\")");
 
         String actualJSON = objectMapper.writeValueAsString(doubleMinAggregator);
@@ -61,27 +80,37 @@ public class DoubleMinAggregatorTest {
     @Test(expectedExceptions = NullPointerException.class)
     public void testNullName() throws JsonProcessingException, JSONException {
 
-        DoubleMinAggregator doubleMinAggregator = new DoubleMinAggregator(null, "Haha");
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void testNullFieldName() throws JsonProcessingException, JSONException {
-
-        DoubleMinAggregator doubleMinAggregator = new DoubleMinAggregator("Name", null);
+        DoubleMinAggregator doubleMinAggregator =
+            DoubleMinAggregator.builder()
+                .fieldName("Haha")
+                .build();
     }
 
     @Test
     public void testEqualsPositive() {
-        DoubleMinAggregator aggregator1 = new DoubleMinAggregator("name", "field");
-        DoubleMinAggregator aggregator2 = new DoubleMinAggregator("name", "field");
+        DoubleMinAggregator aggregator1 =
+            DoubleMinAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        DoubleMinAggregator aggregator3 = new DoubleMinAggregator("name", "field");
+        DoubleMinAggregator aggregator2 =
+            DoubleMinAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        aggregator3.setExpression("(\"foo\" / \"bar\")");
+        DoubleMinAggregator aggregator3 =
+            DoubleMinAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
-        DoubleMinAggregator aggregator4 = new DoubleMinAggregator("name", "field");
-
-        aggregator4.setExpression("(\"foo\" / \"bar\")");
+        DoubleMinAggregator aggregator4 =
+            DoubleMinAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
         Assert.assertEquals(aggregator1, aggregator2);
         Assert.assertEquals(aggregator3, aggregator4);
@@ -89,16 +118,29 @@ public class DoubleMinAggregatorTest {
 
     @Test
     public void testEqualsNegative() {
-        DoubleMinAggregator aggregator1 = new DoubleMinAggregator("name", "field");
-        DoubleMinAggregator aggregator2 = new DoubleMinAggregator("name1", "field1");
+        DoubleMinAggregator aggregator1 =
+            DoubleMinAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        DoubleMinAggregator aggregator3 = new DoubleMinAggregator("name", "field");
+        DoubleMinAggregator aggregator2 =
+            DoubleMinAggregator.builder()
+                .name("name1")
+                .fieldName("field1")
+                .build();
 
-        aggregator3.setExpression("(\"foo\" / \"bar\")");
+        DoubleMinAggregator aggregator3 =
+            DoubleMinAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
-        DoubleMinAggregator aggregator4 = new DoubleMinAggregator("name", "field");
-
-        aggregator4.setExpression("(\"foo\" / \"baz\")");
+        DoubleMinAggregator aggregator4 =
+            DoubleMinAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"baz\")")
+                .build();
 
         Assert.assertNotEquals(aggregator1, aggregator2);
         Assert.assertNotEquals(aggregator3, aggregator4);
@@ -106,9 +148,15 @@ public class DoubleMinAggregatorTest {
 
     @Test
     public void testEqualsWithAnotherSubClass() {
-        DoubleMinAggregator aggregator1 = new DoubleMinAggregator("name", "field");
+        DoubleMinAggregator aggregator1 =
+            DoubleMinAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
+
         CountAggregator aggregator2 = new CountAggregator("countAgg1");
 
         Assert.assertNotEquals(aggregator1, aggregator2);
     }
+
 }

--- a/src/test/java/in/zapr/druid/druidry/aggregator/DoubleMinAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/DoubleMinAggregatorTest.java
@@ -45,10 +45,13 @@ public class DoubleMinAggregatorTest {
         DoubleMinAggregator doubleMinAggregator = new DoubleMinAggregator("CarpeDiem",
                 "Hey");
 
+        doubleMinAggregator.setExpression("(\"foo\" / \"bar\")");
+
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "doubleMin");
         jsonObject.put("name", "CarpeDiem");
         jsonObject.put("fieldName", "Hey");
+        jsonObject.put("expression", "(\"foo\" / \"bar\")");
 
         String actualJSON = objectMapper.writeValueAsString(doubleMinAggregator);
         String expectedJSON = jsonObject.toString();
@@ -72,7 +75,16 @@ public class DoubleMinAggregatorTest {
         DoubleMinAggregator aggregator1 = new DoubleMinAggregator("name", "field");
         DoubleMinAggregator aggregator2 = new DoubleMinAggregator("name", "field");
 
+        DoubleMinAggregator aggregator3 = new DoubleMinAggregator("name", "field");
+
+        aggregator3.setExpression("(\"foo\" / \"bar\")");
+
+        DoubleMinAggregator aggregator4 = new DoubleMinAggregator("name", "field");
+
+        aggregator4.setExpression("(\"foo\" / \"bar\")");
+
         Assert.assertEquals(aggregator1, aggregator2);
+        Assert.assertEquals(aggregator3, aggregator4);
     }
 
     @Test
@@ -80,7 +92,16 @@ public class DoubleMinAggregatorTest {
         DoubleMinAggregator aggregator1 = new DoubleMinAggregator("name", "field");
         DoubleMinAggregator aggregator2 = new DoubleMinAggregator("name1", "field1");
 
+        DoubleMinAggregator aggregator3 = new DoubleMinAggregator("name", "field");
+
+        aggregator3.setExpression("(\"foo\" / \"bar\")");
+
+        DoubleMinAggregator aggregator4 = new DoubleMinAggregator("name", "field");
+
+        aggregator4.setExpression("(\"foo\" / \"baz\")");
+
         Assert.assertNotEquals(aggregator1, aggregator2);
+        Assert.assertNotEquals(aggregator3, aggregator4);
     }
 
     @Test

--- a/src/test/java/in/zapr/druid/druidry/aggregator/DoubleSumAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/DoubleSumAggregatorTest.java
@@ -45,10 +45,13 @@ public class DoubleSumAggregatorTest {
         DoubleSumAggregator doubleSumAggregator = new DoubleSumAggregator("CarpeDiem",
                 "Hey");
 
+        doubleSumAggregator.setExpression("(\"foo\" / \"bar\")");
+
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "doubleSum");
         jsonObject.put("name", "CarpeDiem");
         jsonObject.put("fieldName", "Hey");
+        jsonObject.put("expression", "(\"foo\" / \"bar\")");
 
         String actualJSON = objectMapper.writeValueAsString(doubleSumAggregator);
         String expectedJSON = jsonObject.toString();
@@ -72,7 +75,16 @@ public class DoubleSumAggregatorTest {
         DoubleSumAggregator aggregator1 = new DoubleSumAggregator("name", "field");
         DoubleSumAggregator aggregator2 = new DoubleSumAggregator("name", "field");
 
+        DoubleSumAggregator aggregator3 = new DoubleSumAggregator("name", "field");
+
+        aggregator3.setExpression("(\"foo\" / \"bar\")");
+
+        DoubleSumAggregator aggregator4 = new DoubleSumAggregator("name", "field");
+
+        aggregator4.setExpression("(\"foo\" / \"bar\")");
+
         Assert.assertEquals(aggregator1, aggregator2);
+        Assert.assertEquals(aggregator3, aggregator4);
     }
 
     @Test
@@ -80,7 +92,16 @@ public class DoubleSumAggregatorTest {
         DoubleSumAggregator aggregator1 = new DoubleSumAggregator("name", "field");
         DoubleSumAggregator aggregator2 = new DoubleSumAggregator("name1", "field1");
 
+        DoubleSumAggregator aggregator3 = new DoubleSumAggregator("name", "field");
+
+        aggregator3.setExpression("(\"foo\" / \"bar\")");
+
+        DoubleSumAggregator aggregator4 = new DoubleSumAggregator("name", "field");
+
+        aggregator4.setExpression("(\"foo\" / \"baz\")");
+
         Assert.assertNotEquals(aggregator1, aggregator2);
+        Assert.assertNotEquals(aggregator3, aggregator4);
     }
 
     @Test

--- a/src/test/java/in/zapr/druid/druidry/aggregator/DoubleSumAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/DoubleSumAggregatorTest.java
@@ -40,13 +40,10 @@ public class DoubleSumAggregatorTest {
     }
 
     @Test
-    public void testAllFieldsButExpression() throws JsonProcessingException, JSONException {
+    public void testAllFields() throws JsonProcessingException, JSONException {
 
-        DoubleSumAggregator doubleSumAggregator =
-            DoubleSumAggregator.builder()
-                .name("CarpeDiem")
-                .fieldName("Hey")
-                .build();
+        DoubleSumAggregator doubleSumAggregator = new DoubleSumAggregator("CarpeDiem",
+                "Hey");
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "doubleSum");

--- a/src/test/java/in/zapr/druid/druidry/aggregator/DoubleSumAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/DoubleSumAggregatorTest.java
@@ -40,17 +40,36 @@ public class DoubleSumAggregatorTest {
     }
 
     @Test
-    public void testAllFields() throws JsonProcessingException, JSONException {
+    public void testAllFieldsButExpression() throws JsonProcessingException, JSONException {
 
-        DoubleSumAggregator doubleSumAggregator = new DoubleSumAggregator("CarpeDiem",
-                "Hey");
-
-        doubleSumAggregator.setExpression("(\"foo\" / \"bar\")");
+        DoubleSumAggregator doubleSumAggregator =
+            DoubleSumAggregator.builder()
+                .name("CarpeDiem")
+                .fieldName("Hey")
+                .build();
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "doubleSum");
         jsonObject.put("name", "CarpeDiem");
         jsonObject.put("fieldName", "Hey");
+
+        String actualJSON = objectMapper.writeValueAsString(doubleSumAggregator);
+        String expectedJSON = jsonObject.toString();
+        JSONAssert.assertEquals(expectedJSON, actualJSON, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    public void testAllFieldsButFieldName() throws JsonProcessingException, JSONException {
+
+        DoubleSumAggregator doubleSumAggregator =
+            DoubleSumAggregator.builder()
+                .name("CarpeDiem")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("type", "doubleSum");
+        jsonObject.put("name", "CarpeDiem");
         jsonObject.put("expression", "(\"foo\" / \"bar\")");
 
         String actualJSON = objectMapper.writeValueAsString(doubleSumAggregator);
@@ -61,27 +80,37 @@ public class DoubleSumAggregatorTest {
     @Test(expectedExceptions = NullPointerException.class)
     public void testNullName() throws JsonProcessingException, JSONException {
 
-        DoubleSumAggregator doubleSumAggregator = new DoubleSumAggregator(null, "Haha");
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void testNullFieldName() throws JsonProcessingException, JSONException {
-
-        DoubleSumAggregator doubleSumAggregator = new DoubleSumAggregator("Name", null);
+        DoubleSumAggregator doubleSumAggregator =
+            DoubleSumAggregator.builder()
+                .fieldName("Haha")
+                .build();
     }
 
     @Test
     public void testEqualsPositive() {
-        DoubleSumAggregator aggregator1 = new DoubleSumAggregator("name", "field");
-        DoubleSumAggregator aggregator2 = new DoubleSumAggregator("name", "field");
+        DoubleSumAggregator aggregator1 =
+            DoubleSumAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        DoubleSumAggregator aggregator3 = new DoubleSumAggregator("name", "field");
+        DoubleSumAggregator aggregator2 =
+            DoubleSumAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        aggregator3.setExpression("(\"foo\" / \"bar\")");
+        DoubleSumAggregator aggregator3 =
+            DoubleSumAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
-        DoubleSumAggregator aggregator4 = new DoubleSumAggregator("name", "field");
-
-        aggregator4.setExpression("(\"foo\" / \"bar\")");
+        DoubleSumAggregator aggregator4 =
+            DoubleSumAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
         Assert.assertEquals(aggregator1, aggregator2);
         Assert.assertEquals(aggregator3, aggregator4);
@@ -89,16 +118,29 @@ public class DoubleSumAggregatorTest {
 
     @Test
     public void testEqualsNegative() {
-        DoubleSumAggregator aggregator1 = new DoubleSumAggregator("name", "field");
-        DoubleSumAggregator aggregator2 = new DoubleSumAggregator("name1", "field1");
+        DoubleSumAggregator aggregator1 =
+            DoubleSumAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        DoubleSumAggregator aggregator3 = new DoubleSumAggregator("name", "field");
+        DoubleSumAggregator aggregator2 =
+            DoubleSumAggregator.builder()
+                .name("name1")
+                .fieldName("field1")
+                .build();
 
-        aggregator3.setExpression("(\"foo\" / \"bar\")");
+        DoubleSumAggregator aggregator3 =
+            DoubleSumAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
-        DoubleSumAggregator aggregator4 = new DoubleSumAggregator("name", "field");
-
-        aggregator4.setExpression("(\"foo\" / \"baz\")");
+        DoubleSumAggregator aggregator4 =
+            DoubleSumAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"baz\")")
+                .build();
 
         Assert.assertNotEquals(aggregator1, aggregator2);
         Assert.assertNotEquals(aggregator3, aggregator4);
@@ -106,9 +148,15 @@ public class DoubleSumAggregatorTest {
 
     @Test
     public void testEqualsWithAnotherSubClass() {
-        DoubleSumAggregator aggregator1 = new DoubleSumAggregator("name", "field");
+        DoubleSumAggregator aggregator1 =
+            DoubleSumAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
+
         CountAggregator aggregator2 = new CountAggregator("countAgg1");
 
         Assert.assertNotEquals(aggregator1, aggregator2);
     }
+
 }

--- a/src/test/java/in/zapr/druid/druidry/aggregator/LongMaxAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/LongMaxAggregatorTest.java
@@ -40,17 +40,36 @@ public class LongMaxAggregatorTest {
     }
 
     @Test
-    public void testAllFields() throws JsonProcessingException, JSONException {
+    public void testAllFieldsButExpression() throws JsonProcessingException, JSONException {
 
-        LongMaxAggregator countAggregator = new LongMaxAggregator("CarpeDiem",
-                "Hey");
-
-        countAggregator.setExpression("(\"foo\" / \"bar\")");
+        LongMaxAggregator countAggregator =
+            LongMaxAggregator.builder()
+                .name("CarpeDiem")
+                .fieldName("Hey")
+                .build();
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "longMax");
         jsonObject.put("name", "CarpeDiem");
         jsonObject.put("fieldName", "Hey");
+
+        String actualJSON = objectMapper.writeValueAsString(countAggregator);
+        String expectedJSON = jsonObject.toString();
+        JSONAssert.assertEquals(expectedJSON, actualJSON, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    public void testAllFieldsButFieldName() throws JsonProcessingException, JSONException {
+
+        LongMaxAggregator countAggregator =
+            LongMaxAggregator.builder()
+                .name("CarpeDiem")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("type", "longMax");
+        jsonObject.put("name", "CarpeDiem");
         jsonObject.put("expression", "(\"foo\" / \"bar\")");
 
         String actualJSON = objectMapper.writeValueAsString(countAggregator);
@@ -61,27 +80,37 @@ public class LongMaxAggregatorTest {
     @Test(expectedExceptions = NullPointerException.class)
     public void testNullName() throws JsonProcessingException, JSONException {
 
-        LongMaxAggregator longMaxAggregator = new LongMaxAggregator(null, "Haha");
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void testNullFieldName() throws JsonProcessingException, JSONException {
-
-        LongMaxAggregator longMaxAggregator = new LongMaxAggregator("Name", null);
+        LongMaxAggregator longMaxAggregator =
+            LongMaxAggregator.builder()
+                .fieldName("Haha")
+                .build();
     }
 
     @Test
     public void testEqualsPositive() {
-        LongMaxAggregator aggregator1 = new LongMaxAggregator("name", "field");
-        LongMaxAggregator aggregator2 = new LongMaxAggregator("name", "field");
+        LongMaxAggregator aggregator1 =
+            LongMaxAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        LongMaxAggregator aggregator3 = new LongMaxAggregator("name", "field");
+        LongMaxAggregator aggregator2 =
+            LongMaxAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        aggregator3.setExpression("(\"foo\" / \"bar\")");
+        LongMaxAggregator aggregator3 =
+            LongMaxAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
-        LongMaxAggregator aggregator4 = new LongMaxAggregator("name", "field");
-
-        aggregator4.setExpression("(\"foo\" / \"bar\")");
+        LongMaxAggregator aggregator4 =
+            LongMaxAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
         Assert.assertEquals(aggregator1, aggregator2);
         Assert.assertEquals(aggregator3, aggregator4);
@@ -89,16 +118,29 @@ public class LongMaxAggregatorTest {
 
     @Test
     public void testEqualsNegative() {
-        LongMaxAggregator aggregator1 = new LongMaxAggregator("name", "field");
-        LongMaxAggregator aggregator2 = new LongMaxAggregator("name1", "field1");
+        LongMaxAggregator aggregator1 =
+            LongMaxAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        LongMaxAggregator aggregator3 = new LongMaxAggregator("name", "field");
+        LongMaxAggregator aggregator2 =
+            LongMaxAggregator.builder()
+                .name("name1")
+                .fieldName("field1")
+                .build();
 
-        aggregator3.setExpression("(\"foo\" / \"bar\")");
+        LongMaxAggregator aggregator3 =
+            LongMaxAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
-        LongMaxAggregator aggregator4 = new LongMaxAggregator("name", "field");
-
-        aggregator4.setExpression("(\"foo\" / \"baz\")");
+        LongMaxAggregator aggregator4 =
+            LongMaxAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"baz\")")
+                .build();
 
         Assert.assertNotEquals(aggregator1, aggregator2);
         Assert.assertNotEquals(aggregator3, aggregator4);
@@ -106,9 +148,15 @@ public class LongMaxAggregatorTest {
 
     @Test
     public void testEqualsWithAnotherSubClass() {
-        LongMaxAggregator aggregator1 = new LongMaxAggregator("name", "field");
+        LongMaxAggregator aggregator1 =
+            LongMaxAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
+
         CountAggregator aggregator2 = new CountAggregator("countAgg1");
 
         Assert.assertNotEquals(aggregator1, aggregator2);
     }
+
 }

--- a/src/test/java/in/zapr/druid/druidry/aggregator/LongMaxAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/LongMaxAggregatorTest.java
@@ -45,10 +45,13 @@ public class LongMaxAggregatorTest {
         LongMaxAggregator countAggregator = new LongMaxAggregator("CarpeDiem",
                 "Hey");
 
+        countAggregator.setExpression("(\"foo\" / \"bar\")");
+
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "longMax");
         jsonObject.put("name", "CarpeDiem");
         jsonObject.put("fieldName", "Hey");
+        jsonObject.put("expression", "(\"foo\" / \"bar\")");
 
         String actualJSON = objectMapper.writeValueAsString(countAggregator);
         String expectedJSON = jsonObject.toString();
@@ -72,7 +75,16 @@ public class LongMaxAggregatorTest {
         LongMaxAggregator aggregator1 = new LongMaxAggregator("name", "field");
         LongMaxAggregator aggregator2 = new LongMaxAggregator("name", "field");
 
+        LongMaxAggregator aggregator3 = new LongMaxAggregator("name", "field");
+
+        aggregator3.setExpression("(\"foo\" / \"bar\")");
+
+        LongMaxAggregator aggregator4 = new LongMaxAggregator("name", "field");
+
+        aggregator4.setExpression("(\"foo\" / \"bar\")");
+
         Assert.assertEquals(aggregator1, aggregator2);
+        Assert.assertEquals(aggregator3, aggregator4);
     }
 
     @Test
@@ -80,7 +92,16 @@ public class LongMaxAggregatorTest {
         LongMaxAggregator aggregator1 = new LongMaxAggregator("name", "field");
         LongMaxAggregator aggregator2 = new LongMaxAggregator("name1", "field1");
 
+        LongMaxAggregator aggregator3 = new LongMaxAggregator("name", "field");
+
+        aggregator3.setExpression("(\"foo\" / \"bar\")");
+
+        LongMaxAggregator aggregator4 = new LongMaxAggregator("name", "field");
+
+        aggregator4.setExpression("(\"foo\" / \"baz\")");
+
         Assert.assertNotEquals(aggregator1, aggregator2);
+        Assert.assertNotEquals(aggregator3, aggregator4);
     }
 
     @Test

--- a/src/test/java/in/zapr/druid/druidry/aggregator/LongMaxAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/LongMaxAggregatorTest.java
@@ -40,13 +40,10 @@ public class LongMaxAggregatorTest {
     }
 
     @Test
-    public void testAllFieldsButExpression() throws JsonProcessingException, JSONException {
+    public void testAllFields() throws JsonProcessingException, JSONException {
 
-        LongMaxAggregator countAggregator =
-            LongMaxAggregator.builder()
-                .name("CarpeDiem")
-                .fieldName("Hey")
-                .build();
+        LongMaxAggregator countAggregator = new LongMaxAggregator("CarpeDiem",
+                "Hey");
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "longMax");

--- a/src/test/java/in/zapr/druid/druidry/aggregator/LongMinAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/LongMinAggregatorTest.java
@@ -40,13 +40,10 @@ public class LongMinAggregatorTest {
     }
 
     @Test
-    public void testAllFieldsButExpression() throws JsonProcessingException, JSONException {
+    public void testAllFields() throws JsonProcessingException, JSONException {
 
-        LongMinAggregator longMinAggregator =
-            LongMinAggregator.builder()
-                .name("CarpeDiem")
-                .fieldName("Hey")
-                .build();
+        LongMinAggregator longMinAggregator = new LongMinAggregator("CarpeDiem",
+                "Hey");
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "longMin");

--- a/src/test/java/in/zapr/druid/druidry/aggregator/LongMinAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/LongMinAggregatorTest.java
@@ -40,17 +40,36 @@ public class LongMinAggregatorTest {
     }
 
     @Test
-    public void testAllFields() throws JsonProcessingException, JSONException {
+    public void testAllFieldsButExpression() throws JsonProcessingException, JSONException {
 
-        LongMinAggregator longMinAggregator = new LongMinAggregator("CarpeDiem",
-                "Hey");
-
-        longMinAggregator.setExpression("(\"foo\" / \"bar\")");
+        LongMinAggregator longMinAggregator =
+            LongMinAggregator.builder()
+                .name("CarpeDiem")
+                .fieldName("Hey")
+                .build();
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "longMin");
         jsonObject.put("name", "CarpeDiem");
         jsonObject.put("fieldName", "Hey");
+
+        String actualJSON = objectMapper.writeValueAsString(longMinAggregator);
+        String expectedJSON = jsonObject.toString();
+        JSONAssert.assertEquals(expectedJSON, actualJSON, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    public void testAllFieldsButFieldName() throws JsonProcessingException, JSONException {
+
+        LongMinAggregator longMinAggregator =
+            LongMinAggregator.builder()
+                .name("CarpeDiem")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("type", "longMin");
+        jsonObject.put("name", "CarpeDiem");
         jsonObject.put("expression", "(\"foo\" / \"bar\")");
 
         String actualJSON = objectMapper.writeValueAsString(longMinAggregator);
@@ -61,27 +80,37 @@ public class LongMinAggregatorTest {
     @Test(expectedExceptions = NullPointerException.class)
     public void testNullName() throws JsonProcessingException, JSONException {
 
-        LongMinAggregator longMinAggregator = new LongMinAggregator(null, "Haha");
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void testNullFieldName() throws JsonProcessingException, JSONException {
-
-        LongMinAggregator longMinAggregator = new LongMinAggregator("Name", null);
+        LongMinAggregator longMinAggregator =
+            LongMinAggregator.builder()
+                .fieldName("Haha")
+                .build();
     }
 
     @Test
     public void testEqualsPositive() {
-        LongMinAggregator aggregator1 = new LongMinAggregator("name", "field");
-        LongMinAggregator aggregator2 = new LongMinAggregator("name", "field");
+        LongMinAggregator aggregator1 =
+            LongMinAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        LongMinAggregator aggregator3 = new LongMinAggregator("name", "field");
+        LongMinAggregator aggregator2 =
+            LongMinAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        aggregator3.setExpression("(\"foo\" / \"bar\")");
+        LongMinAggregator aggregator3 =
+            LongMinAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
-        LongMinAggregator aggregator4 = new LongMinAggregator("name", "field");
-
-        aggregator4.setExpression("(\"foo\" / \"bar\")");
+        LongMinAggregator aggregator4 =
+            LongMinAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
         Assert.assertEquals(aggregator1, aggregator2);
         Assert.assertEquals(aggregator3, aggregator4);
@@ -89,16 +118,29 @@ public class LongMinAggregatorTest {
 
     @Test
     public void testEqualsNegative() {
-        LongMinAggregator aggregator1 = new LongMinAggregator("name", "field");
-        LongMinAggregator aggregator2 = new LongMinAggregator("name1", "field1");
+        LongMinAggregator aggregator1 =
+            LongMinAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        LongMinAggregator aggregator3 = new LongMinAggregator("name", "field");
+        LongMinAggregator aggregator2 =
+            LongMinAggregator.builder()
+                .name("name1")
+                .fieldName("field1")
+                .build();
 
-        aggregator3.setExpression("(\"foo\" / \"bar\")");
+        LongMinAggregator aggregator3 =
+            LongMinAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
-        LongMinAggregator aggregator4 = new LongMinAggregator("name", "field");
-
-        aggregator4.setExpression("(\"foo\" / \"baz\")");
+        LongMinAggregator aggregator4 =
+            LongMinAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"baz\")")
+                .build();
 
         Assert.assertNotEquals(aggregator1, aggregator2);
         Assert.assertNotEquals(aggregator3, aggregator4);
@@ -106,9 +148,15 @@ public class LongMinAggregatorTest {
 
     @Test
     public void testEqualsWithAnotherSubClass() {
-        LongMinAggregator aggregator1 = new LongMinAggregator("name", "field");
+        LongMinAggregator aggregator1 =
+            LongMinAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
+
         CountAggregator aggregator2 = new CountAggregator("countAgg1");
 
         Assert.assertNotEquals(aggregator1, aggregator2);
     }
+
 }

--- a/src/test/java/in/zapr/druid/druidry/aggregator/LongMinAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/LongMinAggregatorTest.java
@@ -45,10 +45,13 @@ public class LongMinAggregatorTest {
         LongMinAggregator longMinAggregator = new LongMinAggregator("CarpeDiem",
                 "Hey");
 
+        longMinAggregator.setExpression("(\"foo\" / \"bar\")");
+
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "longMin");
         jsonObject.put("name", "CarpeDiem");
         jsonObject.put("fieldName", "Hey");
+        jsonObject.put("expression", "(\"foo\" / \"bar\")");
 
         String actualJSON = objectMapper.writeValueAsString(longMinAggregator);
         String expectedJSON = jsonObject.toString();
@@ -72,7 +75,16 @@ public class LongMinAggregatorTest {
         LongMinAggregator aggregator1 = new LongMinAggregator("name", "field");
         LongMinAggregator aggregator2 = new LongMinAggregator("name", "field");
 
+        LongMinAggregator aggregator3 = new LongMinAggregator("name", "field");
+
+        aggregator3.setExpression("(\"foo\" / \"bar\")");
+
+        LongMinAggregator aggregator4 = new LongMinAggregator("name", "field");
+
+        aggregator4.setExpression("(\"foo\" / \"bar\")");
+
         Assert.assertEquals(aggregator1, aggregator2);
+        Assert.assertEquals(aggregator3, aggregator4);
     }
 
     @Test
@@ -80,7 +92,16 @@ public class LongMinAggregatorTest {
         LongMinAggregator aggregator1 = new LongMinAggregator("name", "field");
         LongMinAggregator aggregator2 = new LongMinAggregator("name1", "field1");
 
+        LongMinAggregator aggregator3 = new LongMinAggregator("name", "field");
+
+        aggregator3.setExpression("(\"foo\" / \"bar\")");
+
+        LongMinAggregator aggregator4 = new LongMinAggregator("name", "field");
+
+        aggregator4.setExpression("(\"foo\" / \"baz\")");
+
         Assert.assertNotEquals(aggregator1, aggregator2);
+        Assert.assertNotEquals(aggregator3, aggregator4);
     }
 
     @Test

--- a/src/test/java/in/zapr/druid/druidry/aggregator/LongSumAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/LongSumAggregatorTest.java
@@ -40,17 +40,36 @@ public class LongSumAggregatorTest {
     }
 
     @Test
-    public void testAllFields() throws JsonProcessingException, JSONException {
+    public void testAllFieldsButExpression() throws JsonProcessingException, JSONException {
 
-        LongSumAggregator longSumAggregator = new LongSumAggregator("CarpeDiem",
-                "Hey");
-
-        longSumAggregator.setExpression("(\"foo\" / \"bar\")");
+        LongSumAggregator longSumAggregator =
+            LongSumAggregator.builder()
+                .name("CarpeDiem")
+                .fieldName("Hey")
+                .build();
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "longSum");
         jsonObject.put("name", "CarpeDiem");
         jsonObject.put("fieldName", "Hey");
+
+        String actualJSON = objectMapper.writeValueAsString(longSumAggregator);
+        String expectedJSON = jsonObject.toString();
+        JSONAssert.assertEquals(expectedJSON, actualJSON, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    public void testAllFieldsButFieldName() throws JsonProcessingException, JSONException {
+
+        LongSumAggregator longSumAggregator =
+            LongSumAggregator.builder()
+                .name("CarpeDiem")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("type", "longSum");
+        jsonObject.put("name", "CarpeDiem");
         jsonObject.put("expression", "(\"foo\" / \"bar\")");
 
         String actualJSON = objectMapper.writeValueAsString(longSumAggregator);
@@ -61,27 +80,37 @@ public class LongSumAggregatorTest {
     @Test(expectedExceptions = NullPointerException.class)
     public void testNullName() throws JsonProcessingException, JSONException {
 
-        LongSumAggregator longSumAggregator = new LongSumAggregator(null, "Haha");
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void testNullFieldName() throws JsonProcessingException, JSONException {
-
-        LongSumAggregator longSumAggregator = new LongSumAggregator("Name", null);
+        LongSumAggregator longSumAggregator =
+            LongSumAggregator.builder()
+                .fieldName("Haha")
+                .build();
     }
 
     @Test
     public void testEqualsPositive() {
-        LongSumAggregator aggregator1 = new LongSumAggregator("name", "field");
-        LongSumAggregator aggregator2 = new LongSumAggregator("name", "field");
+        LongSumAggregator aggregator1 =
+            LongSumAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        LongSumAggregator aggregator3 = new LongSumAggregator("name", "field");
+        LongSumAggregator aggregator2 =
+            LongSumAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        aggregator3.setExpression("(\"foo\" / \"bar\")");
+        LongSumAggregator aggregator3 =
+            LongSumAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
-        LongSumAggregator aggregator4 = new LongSumAggregator("name", "field");
-
-        aggregator4.setExpression("(\"foo\" / \"bar\")");
+        LongSumAggregator aggregator4 =
+            LongSumAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
         Assert.assertEquals(aggregator1, aggregator2);
         Assert.assertEquals(aggregator3, aggregator4);
@@ -89,16 +118,29 @@ public class LongSumAggregatorTest {
 
     @Test
     public void testEqualsNegative() {
-        LongSumAggregator aggregator1 = new LongSumAggregator("name", "field");
-        LongSumAggregator aggregator2 = new LongSumAggregator("name1", "field1");
+        LongSumAggregator aggregator1 =
+            LongSumAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
 
-        LongSumAggregator aggregator3 = new LongSumAggregator("name", "field");
+        LongSumAggregator aggregator2 =
+            LongSumAggregator.builder()
+                .name("name1")
+                .fieldName("field1")
+                .build();
 
-        aggregator3.setExpression("(\"foo\" / \"bar\")");
+        LongSumAggregator aggregator3 =
+            LongSumAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"bar\")")
+                .build();
 
-        LongSumAggregator aggregator4 = new LongSumAggregator("name", "field");
-
-        aggregator4.setExpression("(\"foo\" / \"baz\")");
+        LongSumAggregator aggregator4 =
+            LongSumAggregator.builder()
+                .name("name")
+                .expression("(\"foo\" / \"baz\")")
+                .build();
 
         Assert.assertNotEquals(aggregator1, aggregator2);
         Assert.assertNotEquals(aggregator3, aggregator4);
@@ -106,9 +148,15 @@ public class LongSumAggregatorTest {
 
     @Test
     public void testEqualsWithAnotherSubClass() {
-        LongSumAggregator aggregator1 = new LongSumAggregator("name", "field");
+        LongSumAggregator aggregator1 =
+            LongSumAggregator.builder()
+                .name("name")
+                .fieldName("field")
+                .build();
+
         CountAggregator aggregator2 = new CountAggregator("countAgg1");
 
         Assert.assertNotEquals(aggregator1, aggregator2);
     }
+
 }

--- a/src/test/java/in/zapr/druid/druidry/aggregator/LongSumAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/LongSumAggregatorTest.java
@@ -40,13 +40,10 @@ public class LongSumAggregatorTest {
     }
 
     @Test
-    public void testAllFieldsButExpression() throws JsonProcessingException, JSONException {
+    public void testAllFields() throws JsonProcessingException, JSONException {
 
-        LongSumAggregator longSumAggregator =
-            LongSumAggregator.builder()
-                .name("CarpeDiem")
-                .fieldName("Hey")
-                .build();
+        LongSumAggregator longSumAggregator = new LongSumAggregator("CarpeDiem",
+                "Hey");
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "longSum");

--- a/src/test/java/in/zapr/druid/druidry/aggregator/LongSumAggregatorTest.java
+++ b/src/test/java/in/zapr/druid/druidry/aggregator/LongSumAggregatorTest.java
@@ -45,10 +45,13 @@ public class LongSumAggregatorTest {
         LongSumAggregator longSumAggregator = new LongSumAggregator("CarpeDiem",
                 "Hey");
 
+        longSumAggregator.setExpression("(\"foo\" / \"bar\")");
+
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("type", "longSum");
         jsonObject.put("name", "CarpeDiem");
         jsonObject.put("fieldName", "Hey");
+        jsonObject.put("expression", "(\"foo\" / \"bar\")");
 
         String actualJSON = objectMapper.writeValueAsString(longSumAggregator);
         String expectedJSON = jsonObject.toString();
@@ -72,7 +75,16 @@ public class LongSumAggregatorTest {
         LongSumAggregator aggregator1 = new LongSumAggregator("name", "field");
         LongSumAggregator aggregator2 = new LongSumAggregator("name", "field");
 
+        LongSumAggregator aggregator3 = new LongSumAggregator("name", "field");
+
+        aggregator3.setExpression("(\"foo\" / \"bar\")");
+
+        LongSumAggregator aggregator4 = new LongSumAggregator("name", "field");
+
+        aggregator4.setExpression("(\"foo\" / \"bar\")");
+
         Assert.assertEquals(aggregator1, aggregator2);
+        Assert.assertEquals(aggregator3, aggregator4);
     }
 
     @Test
@@ -80,7 +92,16 @@ public class LongSumAggregatorTest {
         LongSumAggregator aggregator1 = new LongSumAggregator("name", "field");
         LongSumAggregator aggregator2 = new LongSumAggregator("name1", "field1");
 
+        LongSumAggregator aggregator3 = new LongSumAggregator("name", "field");
+
+        aggregator3.setExpression("(\"foo\" / \"bar\")");
+
+        LongSumAggregator aggregator4 = new LongSumAggregator("name", "field");
+
+        aggregator4.setExpression("(\"foo\" / \"baz\")");
+
         Assert.assertNotEquals(aggregator1, aggregator2);
+        Assert.assertNotEquals(aggregator3, aggregator4);
     }
 
     @Test

--- a/src/test/java/in/zapr/druid/druidry/query/aggregation/GroupByTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/aggregation/GroupByTest.java
@@ -92,8 +92,8 @@ public class GroupByTest {
                 "    ]\n" +
                 "  },\n" +
                 "  \"aggregations\": [\n" +
-                "    { \"type\": \"longSum\", \"name\": \"total_usage\", \"fieldName\": \"user_count\" },\n" +
-                "    { \"type\": \"doubleSum\", \"name\": \"data_transfer\", \"fieldName\": \"data_transfer\" }\n" +
+                "    { \"type\": \"longSum\", \"name\": \"total_usage\", \"fieldName\": \"user_count\", \"expression\": null },\n" +
+                "    { \"type\": \"doubleSum\", \"name\": \"data_transfer\", \"fieldName\": \"data_transfer\", \"expression\": null }\n" +
                 "  ],\n" +
                 "\"having\": {\n" +
                 "    \"type\": \"greaterThan\",\n" +

--- a/src/test/java/in/zapr/druid/druidry/query/aggregation/GroupByTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/aggregation/GroupByTest.java
@@ -19,6 +19,8 @@ package in.zapr.druid.druidry.query.aggregation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import in.zapr.druid.druidry.filter.havingSpec.HavingSpec;
+import in.zapr.druid.druidry.filter.havingSpec.GreaterThanHaving;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.JSONArray;
@@ -33,6 +35,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import in.zapr.druid.druidry.query.config.Context;
+import in.zapr.druid.druidry.query.config.Interval;
 import in.zapr.druid.druidry.aggregator.CountAggregator;
 import in.zapr.druid.druidry.aggregator.DoubleSumAggregator;
 import in.zapr.druid.druidry.aggregator.DruidAggregator;
@@ -44,8 +48,6 @@ import in.zapr.druid.druidry.filter.AndFilter;
 import in.zapr.druid.druidry.filter.DruidFilter;
 import in.zapr.druid.druidry.filter.OrFilter;
 import in.zapr.druid.druidry.filter.SelectorFilter;
-import in.zapr.druid.druidry.filter.havingSpec.GreaterThanHaving;
-import in.zapr.druid.druidry.filter.havingSpec.HavingSpec;
 import in.zapr.druid.druidry.granularity.Granularity;
 import in.zapr.druid.druidry.granularity.PredefinedGranularity;
 import in.zapr.druid.druidry.granularity.SimpleGranularity;
@@ -57,8 +59,6 @@ import in.zapr.druid.druidry.postAggregator.ArithmeticPostAggregator;
 import in.zapr.druid.druidry.postAggregator.ConstantPostAggregator;
 import in.zapr.druid.druidry.postAggregator.DruidPostAggregator;
 import in.zapr.druid.druidry.postAggregator.FieldAccessPostAggregator;
-import in.zapr.druid.druidry.query.config.Context;
-import in.zapr.druid.druidry.query.config.Interval;
 
 public class GroupByTest {
     private static ObjectMapper objectMapper;
@@ -71,47 +71,47 @@ public class GroupByTest {
     @Test
     public void testSampleQuery() throws JsonProcessingException, JSONException {
         String expectedJsonAsString = "{\n" +
-            "  \"queryType\": \"groupBy\",\n" +
-            "  \"dataSource\": {\n" +
-            "    \"type\": \"table\",\n" +
-            "    \"name\": \"sample_datasource\"\n" +
-            "  },\n" +
-            "  \"granularity\": \"day\",\n" +
-            "  \"dimensions\": [\"country\", \"device\"],\n" +
-            "  \"limitSpec\": { \"type\": \"default\", \"limit\": 5000, \"columns\": [\"country\", \"data_transfer\"] },\n" +
-            "  \"filter\": {\n" +
-            "    \"type\": \"and\",\n" +
-            "    \"fields\": [\n" +
-            "      { \"type\": \"selector\", \"dimension\": \"carrier\", \"value\": \"AT&T\" },\n" +
-            "      { \"type\": \"or\", \n" +
-            "        \"fields\": [\n" +
-            "          { \"type\": \"selector\", \"dimension\": \"make\", \"value\": \"Apple\" },\n" +
-            "          { \"type\": \"selector\", \"dimension\": \"make\", \"value\": \"Samsung\" }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ]\n" +
-            "  },\n" +
-            "  \"aggregations\": [\n" +
-            "    { \"type\": \"longSum\", \"name\": \"total_usage\", \"fieldName\": \"user_count\" },\n" +
-            "    { \"type\": \"doubleSum\", \"name\": \"data_transfer\", \"fieldName\": \"data_transfer\" }\n" +
-            "  ],\n" +
-            "\"having\": {\n" +
-            "    \"type\": \"greaterThan\",\n" +
-            "    \"aggregation\": \"total_usage\",\n" +
-            "    \"value\": 2\n" +
-            "  }," +
-            "  \"postAggregations\": [\n" +
-            "    { \"type\": \"arithmetic\",\n" +
-            "      \"name\": \"avg_usage\",\n" +
-            "      \"fn\": \"/\",\n" +
-            "      \"fields\": [\n" +
-            "        { \"type\": \"fieldAccess\", \"fieldName\": \"data_transfer\" },\n" +
-            "        { \"type\": \"fieldAccess\", \"fieldName\": \"total_usage\" }\n" +
-            "      ]\n" +
-            "    }\n" +
-            "  ],\n" +
-            "  \"intervals\": [ \"2012-01-01T00:00:00.000Z/2012-01-03T00:00:00.000Z\" ]\n" +
-            "}\n";
+                "  \"queryType\": \"groupBy\",\n" +
+                "  \"dataSource\": {\n" +
+                "    \"type\": \"table\",\n" +
+                "    \"name\": \"sample_datasource\"\n" +
+                "  },\n" +
+                "  \"granularity\": \"day\",\n" +
+                "  \"dimensions\": [\"country\", \"device\"],\n" +
+                "  \"limitSpec\": { \"type\": \"default\", \"limit\": 5000, \"columns\": [\"country\", \"data_transfer\"] },\n" +
+                "  \"filter\": {\n" +
+                "    \"type\": \"and\",\n" +
+                "    \"fields\": [\n" +
+                "      { \"type\": \"selector\", \"dimension\": \"carrier\", \"value\": \"AT&T\" },\n" +
+                "      { \"type\": \"or\", \n" +
+                "        \"fields\": [\n" +
+                "          { \"type\": \"selector\", \"dimension\": \"make\", \"value\": \"Apple\" },\n" +
+                "          { \"type\": \"selector\", \"dimension\": \"make\", \"value\": \"Samsung\" }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  },\n" +
+                "  \"aggregations\": [\n" +
+                "    { \"type\": \"longSum\", \"name\": \"total_usage\", \"fieldName\": \"user_count\" },\n" +
+                "    { \"type\": \"doubleSum\", \"name\": \"data_transfer\", \"fieldName\": \"data_transfer\" }\n" +
+                "  ],\n" +
+                "\"having\": {\n" +
+                "    \"type\": \"greaterThan\",\n" +
+                "    \"aggregation\": \"total_usage\",\n" +
+                "    \"value\": 2\n" +
+                "  }," +
+                "  \"postAggregations\": [\n" +
+                "    { \"type\": \"arithmetic\",\n" +
+                "      \"name\": \"avg_usage\",\n" +
+                "      \"fn\": \"/\",\n" +
+                "      \"fields\": [\n" +
+                "        { \"type\": \"fieldAccess\", \"fieldName\": \"data_transfer\" },\n" +
+                "        { \"type\": \"fieldAccess\", \"fieldName\": \"total_usage\" }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"intervals\": [ \"2012-01-01T00:00:00.000Z/2012-01-03T00:00:00.000Z\" ]\n" +
+                "}\n";
 
         // Druid dimensions
         DruidDimension druidDimension1 = new SimpleDimension("country");
@@ -119,8 +119,8 @@ public class GroupByTest {
 
         // Limit Spec
         List<OrderByColumnSpec> orderByColumnSpecs
-            = Arrays.asList(new OrderByColumnSpecString("country"),
-            new OrderByColumnSpecString("data_transfer"));
+                = Arrays.asList(new OrderByColumnSpecString("country"),
+                new OrderByColumnSpecString("data_transfer"));
         DefaultLimitSpec limitSpec = new DefaultLimitSpec(5000, orderByColumnSpecs);
 
         // Filters
@@ -132,17 +132,8 @@ public class GroupByTest {
         DruidFilter filter = new AndFilter(Arrays.asList(carrierFilter, makeFilter));
 
         // Aggregations
-        DruidAggregator usageAggregator =
-            LongSumAggregator.builder()
-                .name("total_usage")
-                .fieldName("user_count")
-                .build();
-
-        DruidAggregator transferAggregator =
-            DoubleSumAggregator.builder()
-                .name("data_transfer")
-                .fieldName("data_transfer")
-                .build();
+        DruidAggregator usageAggregator = new LongSumAggregator("total_usage", "user_count");
+        DruidAggregator transferAggregator = new DoubleSumAggregator("data_transfer", "data_transfer");
 
         // Having
         HavingSpec countHaving = new GreaterThanHaving("total_usage", 2);
@@ -152,10 +143,10 @@ public class GroupByTest {
         DruidPostAggregator usagePostAggregator = new FieldAccessPostAggregator("data_transfer");
 
         DruidPostAggregator postAggregator = ArithmeticPostAggregator.builder()
-            .name("avg_usage")
-            .function(ArithmeticFunction.DIVIDE)
-            .fields(Arrays.asList(transferPostAggregator, usagePostAggregator))
-            .build();
+                .name("avg_usage")
+                .function(ArithmeticFunction.DIVIDE)
+                .fields(Arrays.asList(transferPostAggregator, usagePostAggregator))
+                .build();
 
         // Interval
         DateTime startTime = new DateTime(2012, 1, 1, 0, 0, 0, DateTimeZone.UTC);
@@ -163,16 +154,16 @@ public class GroupByTest {
         Interval interval = new Interval(startTime, endTime);
 
         DruidGroupByQuery query = DruidGroupByQuery.builder()
-            .dataSource(new TableDataSource("sample_datasource"))
-            .granularity(new SimpleGranularity(PredefinedGranularity.DAY))
-            .dimensions(Arrays.asList(druidDimension1, druidDimension2))
-            .limitSpec(limitSpec)
-            .filter(filter)
-            .having(countHaving)
-            .aggregators(Arrays.asList(usageAggregator, transferAggregator))
-            .postAggregators(Collections.singletonList(postAggregator))
-            .intervals(Collections.singletonList(interval))
-            .build();
+                .dataSource(new TableDataSource("sample_datasource"))
+                .granularity(new SimpleGranularity(PredefinedGranularity.DAY))
+                .dimensions(Arrays.asList(druidDimension1, druidDimension2))
+                .limitSpec(limitSpec)
+                .filter(filter)
+                .having(countHaving)
+                .aggregators(Arrays.asList(usageAggregator, transferAggregator))
+                .postAggregators(Collections.singletonList(postAggregator))
+                .intervals(Collections.singletonList(interval))
+                .build();
 
         String actualJson = objectMapper.writeValueAsString(query);
         JSONAssert.assertEquals(actualJson, expectedJsonAsString, JSONCompareMode.NON_EXTENSIBLE);
@@ -190,11 +181,11 @@ public class GroupByTest {
         Interval interval = new Interval(startTime, endTime);
 
         DruidGroupByQuery druidGroupByQuery = DruidGroupByQuery.builder()
-            .dataSource(new TableDataSource("sample_datasource"))
-            .dimensions(Arrays.asList(druidDimension1, druidDimension2))
-            .granularity(granularity)
-            .intervals(Collections.singletonList(interval))
-            .build();
+                .dataSource(new TableDataSource("sample_datasource"))
+                .dimensions(Arrays.asList(druidDimension1, druidDimension2))
+                .granularity(granularity)
+                .intervals(Collections.singletonList(interval))
+                .build();
 
         String actualJson = objectMapper.writeValueAsString(druidGroupByQuery);
 
@@ -230,19 +221,19 @@ public class GroupByTest {
         DruidAggregator aggregator = new CountAggregator("Chill");
         DruidPostAggregator postAggregator = new ConstantPostAggregator("Keep", 16.11);
         Context context = Context.builder()
-            .populateCache(true)
-            .build();
+                .populateCache(true)
+                .build();
 
         DruidGroupByQuery druidGroupByQuery = DruidGroupByQuery.builder()
-            .dataSource(new TableDataSource("sample_datasource"))
-            .dimensions(Arrays.asList(druidDimension1, druidDimension2))
-            .granularity(granularity)
-            .filter(filter)
-            .aggregators(Collections.singletonList(aggregator))
-            .postAggregators(Collections.singletonList(postAggregator))
-            .intervals(Collections.singletonList(interval))
-            .context(context)
-            .build();
+                .dataSource(new TableDataSource("sample_datasource"))
+                .dimensions(Arrays.asList(druidDimension1, druidDimension2))
+                .granularity(granularity)
+                .filter(filter)
+                .aggregators(Collections.singletonList(aggregator))
+                .postAggregators(Collections.singletonList(postAggregator))
+                .intervals(Collections.singletonList(interval))
+                .context(context)
+                .build();
 
         String actualJson = objectMapper.writeValueAsString(druidGroupByQuery);
 
@@ -264,7 +255,7 @@ public class GroupByTest {
         expectedContext.put("populateCache", true);
 
         JSONArray intervalArray = new JSONArray(Collections.singletonList("2012-01-01T00:00:00.000Z/" +
-            "2012-01-03T00:00:00.000Z"));
+                "2012-01-03T00:00:00.000Z"));
         JSONArray dimensionArray = new JSONArray(Arrays.asList("dim1", "dim2"));
 
         JSONObject dataSource = new JSONObject();

--- a/src/test/java/in/zapr/druid/druidry/query/aggregation/GroupByTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/aggregation/GroupByTest.java
@@ -19,8 +19,6 @@ package in.zapr.druid.druidry.query.aggregation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import in.zapr.druid.druidry.filter.havingSpec.HavingSpec;
-import in.zapr.druid.druidry.filter.havingSpec.GreaterThanHaving;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.JSONArray;
@@ -35,8 +33,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import in.zapr.druid.druidry.query.config.Context;
-import in.zapr.druid.druidry.query.config.Interval;
 import in.zapr.druid.druidry.aggregator.CountAggregator;
 import in.zapr.druid.druidry.aggregator.DoubleSumAggregator;
 import in.zapr.druid.druidry.aggregator.DruidAggregator;
@@ -48,6 +44,8 @@ import in.zapr.druid.druidry.filter.AndFilter;
 import in.zapr.druid.druidry.filter.DruidFilter;
 import in.zapr.druid.druidry.filter.OrFilter;
 import in.zapr.druid.druidry.filter.SelectorFilter;
+import in.zapr.druid.druidry.filter.havingSpec.GreaterThanHaving;
+import in.zapr.druid.druidry.filter.havingSpec.HavingSpec;
 import in.zapr.druid.druidry.granularity.Granularity;
 import in.zapr.druid.druidry.granularity.PredefinedGranularity;
 import in.zapr.druid.druidry.granularity.SimpleGranularity;
@@ -59,6 +57,8 @@ import in.zapr.druid.druidry.postAggregator.ArithmeticPostAggregator;
 import in.zapr.druid.druidry.postAggregator.ConstantPostAggregator;
 import in.zapr.druid.druidry.postAggregator.DruidPostAggregator;
 import in.zapr.druid.druidry.postAggregator.FieldAccessPostAggregator;
+import in.zapr.druid.druidry.query.config.Context;
+import in.zapr.druid.druidry.query.config.Interval;
 
 public class GroupByTest {
     private static ObjectMapper objectMapper;
@@ -71,47 +71,47 @@ public class GroupByTest {
     @Test
     public void testSampleQuery() throws JsonProcessingException, JSONException {
         String expectedJsonAsString = "{\n" +
-                "  \"queryType\": \"groupBy\",\n" +
-                "  \"dataSource\": {\n" +
-                "    \"type\": \"table\",\n" +
-                "    \"name\": \"sample_datasource\"\n" +
-                "  },\n" +
-                "  \"granularity\": \"day\",\n" +
-                "  \"dimensions\": [\"country\", \"device\"],\n" +
-                "  \"limitSpec\": { \"type\": \"default\", \"limit\": 5000, \"columns\": [\"country\", \"data_transfer\"] },\n" +
-                "  \"filter\": {\n" +
-                "    \"type\": \"and\",\n" +
-                "    \"fields\": [\n" +
-                "      { \"type\": \"selector\", \"dimension\": \"carrier\", \"value\": \"AT&T\" },\n" +
-                "      { \"type\": \"or\", \n" +
-                "        \"fields\": [\n" +
-                "          { \"type\": \"selector\", \"dimension\": \"make\", \"value\": \"Apple\" },\n" +
-                "          { \"type\": \"selector\", \"dimension\": \"make\", \"value\": \"Samsung\" }\n" +
-                "        ]\n" +
-                "      }\n" +
-                "    ]\n" +
-                "  },\n" +
-                "  \"aggregations\": [\n" +
-                "    { \"type\": \"longSum\", \"name\": \"total_usage\", \"fieldName\": \"user_count\", \"expression\": null },\n" +
-                "    { \"type\": \"doubleSum\", \"name\": \"data_transfer\", \"fieldName\": \"data_transfer\", \"expression\": null }\n" +
-                "  ],\n" +
-                "\"having\": {\n" +
-                "    \"type\": \"greaterThan\",\n" +
-                "    \"aggregation\": \"total_usage\",\n" +
-                "    \"value\": 2\n" +
-                "  }," +
-                "  \"postAggregations\": [\n" +
-                "    { \"type\": \"arithmetic\",\n" +
-                "      \"name\": \"avg_usage\",\n" +
-                "      \"fn\": \"/\",\n" +
-                "      \"fields\": [\n" +
-                "        { \"type\": \"fieldAccess\", \"fieldName\": \"data_transfer\" },\n" +
-                "        { \"type\": \"fieldAccess\", \"fieldName\": \"total_usage\" }\n" +
-                "      ]\n" +
-                "    }\n" +
-                "  ],\n" +
-                "  \"intervals\": [ \"2012-01-01T00:00:00.000Z/2012-01-03T00:00:00.000Z\" ]\n" +
-                "}\n";
+            "  \"queryType\": \"groupBy\",\n" +
+            "  \"dataSource\": {\n" +
+            "    \"type\": \"table\",\n" +
+            "    \"name\": \"sample_datasource\"\n" +
+            "  },\n" +
+            "  \"granularity\": \"day\",\n" +
+            "  \"dimensions\": [\"country\", \"device\"],\n" +
+            "  \"limitSpec\": { \"type\": \"default\", \"limit\": 5000, \"columns\": [\"country\", \"data_transfer\"] },\n" +
+            "  \"filter\": {\n" +
+            "    \"type\": \"and\",\n" +
+            "    \"fields\": [\n" +
+            "      { \"type\": \"selector\", \"dimension\": \"carrier\", \"value\": \"AT&T\" },\n" +
+            "      { \"type\": \"or\", \n" +
+            "        \"fields\": [\n" +
+            "          { \"type\": \"selector\", \"dimension\": \"make\", \"value\": \"Apple\" },\n" +
+            "          { \"type\": \"selector\", \"dimension\": \"make\", \"value\": \"Samsung\" }\n" +
+            "        ]\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  },\n" +
+            "  \"aggregations\": [\n" +
+            "    { \"type\": \"longSum\", \"name\": \"total_usage\", \"fieldName\": \"user_count\" },\n" +
+            "    { \"type\": \"doubleSum\", \"name\": \"data_transfer\", \"fieldName\": \"data_transfer\" }\n" +
+            "  ],\n" +
+            "\"having\": {\n" +
+            "    \"type\": \"greaterThan\",\n" +
+            "    \"aggregation\": \"total_usage\",\n" +
+            "    \"value\": 2\n" +
+            "  }," +
+            "  \"postAggregations\": [\n" +
+            "    { \"type\": \"arithmetic\",\n" +
+            "      \"name\": \"avg_usage\",\n" +
+            "      \"fn\": \"/\",\n" +
+            "      \"fields\": [\n" +
+            "        { \"type\": \"fieldAccess\", \"fieldName\": \"data_transfer\" },\n" +
+            "        { \"type\": \"fieldAccess\", \"fieldName\": \"total_usage\" }\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"intervals\": [ \"2012-01-01T00:00:00.000Z/2012-01-03T00:00:00.000Z\" ]\n" +
+            "}\n";
 
         // Druid dimensions
         DruidDimension druidDimension1 = new SimpleDimension("country");
@@ -119,8 +119,8 @@ public class GroupByTest {
 
         // Limit Spec
         List<OrderByColumnSpec> orderByColumnSpecs
-                = Arrays.asList(new OrderByColumnSpecString("country"),
-                new OrderByColumnSpecString("data_transfer"));
+            = Arrays.asList(new OrderByColumnSpecString("country"),
+            new OrderByColumnSpecString("data_transfer"));
         DefaultLimitSpec limitSpec = new DefaultLimitSpec(5000, orderByColumnSpecs);
 
         // Filters
@@ -132,8 +132,17 @@ public class GroupByTest {
         DruidFilter filter = new AndFilter(Arrays.asList(carrierFilter, makeFilter));
 
         // Aggregations
-        DruidAggregator usageAggregator = new LongSumAggregator("total_usage", "user_count");
-        DruidAggregator transferAggregator = new DoubleSumAggregator("data_transfer", "data_transfer");
+        DruidAggregator usageAggregator =
+            LongSumAggregator.builder()
+                .name("total_usage")
+                .fieldName("user_count")
+                .build();
+
+        DruidAggregator transferAggregator =
+            DoubleSumAggregator.builder()
+                .name("data_transfer")
+                .fieldName("data_transfer")
+                .build();
 
         // Having
         HavingSpec countHaving = new GreaterThanHaving("total_usage", 2);
@@ -143,10 +152,10 @@ public class GroupByTest {
         DruidPostAggregator usagePostAggregator = new FieldAccessPostAggregator("data_transfer");
 
         DruidPostAggregator postAggregator = ArithmeticPostAggregator.builder()
-                .name("avg_usage")
-                .function(ArithmeticFunction.DIVIDE)
-                .fields(Arrays.asList(transferPostAggregator, usagePostAggregator))
-                .build();
+            .name("avg_usage")
+            .function(ArithmeticFunction.DIVIDE)
+            .fields(Arrays.asList(transferPostAggregator, usagePostAggregator))
+            .build();
 
         // Interval
         DateTime startTime = new DateTime(2012, 1, 1, 0, 0, 0, DateTimeZone.UTC);
@@ -154,16 +163,16 @@ public class GroupByTest {
         Interval interval = new Interval(startTime, endTime);
 
         DruidGroupByQuery query = DruidGroupByQuery.builder()
-                .dataSource(new TableDataSource("sample_datasource"))
-                .granularity(new SimpleGranularity(PredefinedGranularity.DAY))
-                .dimensions(Arrays.asList(druidDimension1, druidDimension2))
-                .limitSpec(limitSpec)
-                .filter(filter)
-                .having(countHaving)
-                .aggregators(Arrays.asList(usageAggregator, transferAggregator))
-                .postAggregators(Collections.singletonList(postAggregator))
-                .intervals(Collections.singletonList(interval))
-                .build();
+            .dataSource(new TableDataSource("sample_datasource"))
+            .granularity(new SimpleGranularity(PredefinedGranularity.DAY))
+            .dimensions(Arrays.asList(druidDimension1, druidDimension2))
+            .limitSpec(limitSpec)
+            .filter(filter)
+            .having(countHaving)
+            .aggregators(Arrays.asList(usageAggregator, transferAggregator))
+            .postAggregators(Collections.singletonList(postAggregator))
+            .intervals(Collections.singletonList(interval))
+            .build();
 
         String actualJson = objectMapper.writeValueAsString(query);
         JSONAssert.assertEquals(actualJson, expectedJsonAsString, JSONCompareMode.NON_EXTENSIBLE);
@@ -181,11 +190,11 @@ public class GroupByTest {
         Interval interval = new Interval(startTime, endTime);
 
         DruidGroupByQuery druidGroupByQuery = DruidGroupByQuery.builder()
-                .dataSource(new TableDataSource("sample_datasource"))
-                .dimensions(Arrays.asList(druidDimension1, druidDimension2))
-                .granularity(granularity)
-                .intervals(Collections.singletonList(interval))
-                .build();
+            .dataSource(new TableDataSource("sample_datasource"))
+            .dimensions(Arrays.asList(druidDimension1, druidDimension2))
+            .granularity(granularity)
+            .intervals(Collections.singletonList(interval))
+            .build();
 
         String actualJson = objectMapper.writeValueAsString(druidGroupByQuery);
 
@@ -221,19 +230,19 @@ public class GroupByTest {
         DruidAggregator aggregator = new CountAggregator("Chill");
         DruidPostAggregator postAggregator = new ConstantPostAggregator("Keep", 16.11);
         Context context = Context.builder()
-                .populateCache(true)
-                .build();
+            .populateCache(true)
+            .build();
 
         DruidGroupByQuery druidGroupByQuery = DruidGroupByQuery.builder()
-                .dataSource(new TableDataSource("sample_datasource"))
-                .dimensions(Arrays.asList(druidDimension1, druidDimension2))
-                .granularity(granularity)
-                .filter(filter)
-                .aggregators(Collections.singletonList(aggregator))
-                .postAggregators(Collections.singletonList(postAggregator))
-                .intervals(Collections.singletonList(interval))
-                .context(context)
-                .build();
+            .dataSource(new TableDataSource("sample_datasource"))
+            .dimensions(Arrays.asList(druidDimension1, druidDimension2))
+            .granularity(granularity)
+            .filter(filter)
+            .aggregators(Collections.singletonList(aggregator))
+            .postAggregators(Collections.singletonList(postAggregator))
+            .intervals(Collections.singletonList(interval))
+            .context(context)
+            .build();
 
         String actualJson = objectMapper.writeValueAsString(druidGroupByQuery);
 
@@ -255,7 +264,7 @@ public class GroupByTest {
         expectedContext.put("populateCache", true);
 
         JSONArray intervalArray = new JSONArray(Collections.singletonList("2012-01-01T00:00:00.000Z/" +
-                "2012-01-03T00:00:00.000Z"));
+            "2012-01-03T00:00:00.000Z"));
         JSONArray dimensionArray = new JSONArray(Arrays.asList("dim1", "dim2"));
 
         JSONObject dataSource = new JSONObject();

--- a/src/test/java/in/zapr/druid/druidry/query/aggregation/TimeSeriesTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/aggregation/TimeSeriesTest.java
@@ -136,8 +136,8 @@ public class TimeSeriesTest {
                 "    ]\n" +
                 "  },\n" +
                 "  \"aggregations\": [\n" +
-                "    { \"type\": \"longSum\", \"name\": \"sample_name1\", \"fieldName\": \"sample_fieldName1\" },\n" +
-                "    { \"type\": \"doubleSum\", \"name\": \"sample_name2\", \"fieldName\": \"sample_fieldName2\" }\n" +
+                "    { \"type\": \"longSum\", \"name\": \"sample_name1\", \"fieldName\": \"sample_fieldName1\", \"expression\": null },\n" +
+                "    { \"type\": \"doubleSum\", \"name\": \"sample_name2\", \"fieldName\": \"sample_fieldName2\", \"expression\": null }\n" +
                 "  ],\n" +
                 "  \"postAggregations\": [\n" +
                 "    { \"type\": \"arithmetic\",\n" +

--- a/src/test/java/in/zapr/druid/druidry/query/aggregation/TimeSeriesTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/aggregation/TimeSeriesTest.java
@@ -33,8 +33,6 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.Collections;
 
-import in.zapr.druid.druidry.query.config.Context;
-import in.zapr.druid.druidry.query.config.Interval;
 import in.zapr.druid.druidry.aggregator.CountAggregator;
 import in.zapr.druid.druidry.aggregator.DoubleSumAggregator;
 import in.zapr.druid.druidry.aggregator.DruidAggregator;
@@ -52,6 +50,8 @@ import in.zapr.druid.druidry.postAggregator.ArithmeticPostAggregator;
 import in.zapr.druid.druidry.postAggregator.ConstantPostAggregator;
 import in.zapr.druid.druidry.postAggregator.DruidPostAggregator;
 import in.zapr.druid.druidry.postAggregator.FieldAccessPostAggregator;
+import in.zapr.druid.druidry.query.config.Context;
+import in.zapr.druid.druidry.query.config.Interval;
 
 public class TimeSeriesTest {
     private static ObjectMapper objectMapper;
@@ -61,42 +61,49 @@ public class TimeSeriesTest {
         objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JodaModule());
         objectMapper.configure(com.fasterxml.jackson.databind.SerializationFeature.
-                WRITE_DATES_AS_TIMESTAMPS, false);
+            WRITE_DATES_AS_TIMESTAMPS, false);
     }
 
     @Test
     public void testSampleQuery() throws JsonProcessingException, JSONException {
 
         SelectorFilter selectorFilter2 = new SelectorFilter("sample_dimension2",
-                "sample_value2");
+            "sample_value2");
         SelectorFilter selectorFilter3 = new SelectorFilter("sample_dimension3",
-                "sample_value3");
+            "sample_value3");
 
         OrFilter orfilter = new OrFilter(Arrays.asList(selectorFilter2, selectorFilter3));
 
         SelectorFilter selectorFilter1 = new SelectorFilter("sample_dimension1",
-                "sample_value1");
+            "sample_value1");
 
         AndFilter andFilter = new AndFilter(Arrays.asList(selectorFilter1, orfilter));
 
-        DruidAggregator aggregator1 = new LongSumAggregator("sample_name1",
-                "sample_fieldName1");
-        DruidAggregator aggregator2 = new DoubleSumAggregator("sample_name2",
-                "sample_fieldName2");
+        DruidAggregator aggregator1 =
+            LongSumAggregator.builder()
+                .name("sample_name1")
+                .fieldName("sample_fieldName1")
+                .build();
+
+        DruidAggregator aggregator2 =
+            DoubleSumAggregator.builder()
+                .name("sample_name2")
+                .fieldName("sample_fieldName2")
+                .build();
 
         FieldAccessPostAggregator fieldAccessPostAggregator1
-                = new FieldAccessPostAggregator("postAgg__sample_name1",
-                "sample_name1");
+            = new FieldAccessPostAggregator("postAgg__sample_name1",
+            "sample_name1");
 
         FieldAccessPostAggregator fieldAccessPostAggregator2
-                = new FieldAccessPostAggregator("postAgg__sample_name2",
-                "sample_name2");
+            = new FieldAccessPostAggregator("postAgg__sample_name2",
+            "sample_name2");
 
         DruidPostAggregator postAggregator = ArithmeticPostAggregator.builder()
-                .name("sample_divide")
-                .function(ArithmeticFunction.DIVIDE)
-                .fields(Arrays.asList(fieldAccessPostAggregator1, fieldAccessPostAggregator2))
-                .build();
+            .name("sample_divide")
+            .function(ArithmeticFunction.DIVIDE)
+            .fields(Arrays.asList(fieldAccessPostAggregator1, fieldAccessPostAggregator2))
+            .build();
 
         //2013-08-31T00:00:00.000/2013-09-03T00:00:00.000"
         DateTime startTime = new DateTime(2012, 1, 1, 0, 0, 0, DateTimeZone.UTC);
@@ -106,51 +113,51 @@ public class TimeSeriesTest {
         Granularity granularity = new SimpleGranularity(PredefinedGranularity.DAY);
 
         DruidTimeSeriesQuery query = DruidTimeSeriesQuery.builder()
-                .dataSource(new TableDataSource("sample_datasource"))
-                .granularity(granularity)
-                .descending(true)
-                .filter(andFilter)
-                .aggregators(Arrays.asList(aggregator1, aggregator2))
-                .postAggregators(Collections.singletonList(postAggregator))
-                .intervals(Collections.singletonList(interval))
-                .build();
+            .dataSource(new TableDataSource("sample_datasource"))
+            .granularity(granularity)
+            .descending(true)
+            .filter(andFilter)
+            .aggregators(Arrays.asList(aggregator1, aggregator2))
+            .postAggregators(Collections.singletonList(postAggregator))
+            .intervals(Collections.singletonList(interval))
+            .build();
 
         String expectedJsonAsString = "{\n" +
-                "  \"queryType\": \"timeseries\",\n" +
-                "  \"dataSource\": {\n" +
-                "    \"type\": \"table\",\n" +
-                "    \"name\": \"sample_datasource\"\n" +
-                "  },\n" +
-                "  \"granularity\": \"day\",\n" +
-                "  \"descending\": true,\n" +
-                "  \"filter\": {\n" +
-                "    \"type\": \"and\",\n" +
-                "    \"fields\": [\n" +
-                "      { \"type\": \"selector\", \"dimension\": \"sample_dimension1\", \"value\": \"sample_value1\" },\n" +
-                "      { \"type\": \"or\",\n" +
-                "        \"fields\": [\n" +
-                "          { \"type\": \"selector\", \"dimension\": \"sample_dimension2\", \"value\": \"sample_value2\" },\n" +
-                "          { \"type\": \"selector\", \"dimension\": \"sample_dimension3\", \"value\": \"sample_value3\" }\n" +
-                "        ]\n" +
-                "      }\n" +
-                "    ]\n" +
-                "  },\n" +
-                "  \"aggregations\": [\n" +
-                "    { \"type\": \"longSum\", \"name\": \"sample_name1\", \"fieldName\": \"sample_fieldName1\", \"expression\": null },\n" +
-                "    { \"type\": \"doubleSum\", \"name\": \"sample_name2\", \"fieldName\": \"sample_fieldName2\", \"expression\": null }\n" +
-                "  ],\n" +
-                "  \"postAggregations\": [\n" +
-                "    { \"type\": \"arithmetic\",\n" +
-                "      \"name\": \"sample_divide\",\n" +
-                "      \"fn\": \"/\",\n" +
-                "      \"fields\": [\n" +
-                "        { \"type\": \"fieldAccess\", \"name\": \"postAgg__sample_name1\", \"fieldName\": \"sample_name1\" },\n" +
-                "        { \"type\": \"fieldAccess\", \"name\": \"postAgg__sample_name2\", \"fieldName\": \"sample_name2\" }\n" +
-                "      ]\n" +
-                "    }\n" +
-                "  ],\n" +
-                "  \"intervals\": [ \"2012-01-01T00:00:00.000Z/2012-01-03T00:00:00.000Z\" ]\n" +
-                "}";
+            "  \"queryType\": \"timeseries\",\n" +
+            "  \"dataSource\": {\n" +
+            "    \"type\": \"table\",\n" +
+            "    \"name\": \"sample_datasource\"\n" +
+            "  },\n" +
+            "  \"granularity\": \"day\",\n" +
+            "  \"descending\": true,\n" +
+            "  \"filter\": {\n" +
+            "    \"type\": \"and\",\n" +
+            "    \"fields\": [\n" +
+            "      { \"type\": \"selector\", \"dimension\": \"sample_dimension1\", \"value\": \"sample_value1\" },\n" +
+            "      { \"type\": \"or\",\n" +
+            "        \"fields\": [\n" +
+            "          { \"type\": \"selector\", \"dimension\": \"sample_dimension2\", \"value\": \"sample_value2\" },\n" +
+            "          { \"type\": \"selector\", \"dimension\": \"sample_dimension3\", \"value\": \"sample_value3\" }\n" +
+            "        ]\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  },\n" +
+            "  \"aggregations\": [\n" +
+            "    { \"type\": \"longSum\", \"name\": \"sample_name1\", \"fieldName\": \"sample_fieldName1\" },\n" +
+            "    { \"type\": \"doubleSum\", \"name\": \"sample_name2\", \"fieldName\": \"sample_fieldName2\" }\n" +
+            "  ],\n" +
+            "  \"postAggregations\": [\n" +
+            "    { \"type\": \"arithmetic\",\n" +
+            "      \"name\": \"sample_divide\",\n" +
+            "      \"fn\": \"/\",\n" +
+            "      \"fields\": [\n" +
+            "        { \"type\": \"fieldAccess\", \"name\": \"postAgg__sample_name1\", \"fieldName\": \"sample_name1\" },\n" +
+            "        { \"type\": \"fieldAccess\", \"name\": \"postAgg__sample_name2\", \"fieldName\": \"sample_name2\" }\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"intervals\": [ \"2012-01-01T00:00:00.000Z/2012-01-03T00:00:00.000Z\" ]\n" +
+            "}";
 
         String actualJson = objectMapper.writeValueAsString(query);
         JSONAssert.assertEquals(actualJson, expectedJsonAsString, JSONCompareMode.NON_EXTENSIBLE);
@@ -165,10 +172,10 @@ public class TimeSeriesTest {
         Granularity granularity = new SimpleGranularity(PredefinedGranularity.DAY);
 
         DruidTimeSeriesQuery seriesQuery = DruidTimeSeriesQuery.builder()
-                .dataSource(new TableDataSource("Matrix"))
-                .intervals(Collections.singletonList(interval))
-                .granularity(granularity)
-                .build();
+            .dataSource(new TableDataSource("Matrix"))
+            .intervals(Collections.singletonList(interval))
+            .granularity(granularity)
+            .build();
 
         JSONObject dataSource = new JSONObject();
         dataSource.put("type", "table");
@@ -178,7 +185,7 @@ public class TimeSeriesTest {
         expectedQuery.put("queryType", "timeseries");
         expectedQuery.put("dataSource", dataSource);
         expectedQuery.put("intervals", new JSONArray(Collections
-                .singletonList("2013-07-14T00:00:00.000Z/2013-11-16T00:00:00.000Z")));
+            .singletonList("2013-07-14T00:00:00.000Z/2013-11-16T00:00:00.000Z")));
         expectedQuery.put("granularity", "day");
 
         String actualJson = objectMapper.writeValueAsString(seriesQuery);
@@ -194,23 +201,23 @@ public class TimeSeriesTest {
         Granularity granularity = new SimpleGranularity(PredefinedGranularity.DAY);
 
         Context context = Context.builder()
-                .useCache(true)
-                .build();
+            .useCache(true)
+            .build();
 
         DruidFilter filter = new SelectorFilter("Spread", "Peace");
         DruidAggregator aggregator = new CountAggregator("Chill");
         DruidPostAggregator postAggregator = new ConstantPostAggregator("Keep", 10.47);
 
         DruidTimeSeriesQuery seriesQuery = DruidTimeSeriesQuery.builder()
-                .dataSource(new TableDataSource("Matrix"))
-                .descending(true)
-                .intervals(Collections.singletonList(interval))
-                .granularity(granularity)
-                .filter(filter)
-                .aggregators(Collections.singletonList(aggregator))
-                .postAggregators(Collections.singletonList(postAggregator))
-                .context(context)
-                .build();
+            .dataSource(new TableDataSource("Matrix"))
+            .descending(true)
+            .intervals(Collections.singletonList(interval))
+            .granularity(granularity)
+            .filter(filter)
+            .aggregators(Collections.singletonList(aggregator))
+            .postAggregators(Collections.singletonList(postAggregator))
+            .context(context)
+            .build();
 
         JSONObject expectedFilter = new JSONObject();
         expectedFilter.put("type", "selector");
@@ -237,7 +244,7 @@ public class TimeSeriesTest {
         expectedQuery.put("queryType", "timeseries");
         expectedQuery.put("dataSource", dataSource);
         expectedQuery.put("intervals", new JSONArray(Collections
-                .singletonList("2013-07-14T00:00:00.000Z/2013-11-16T00:00:00.000Z")));
+            .singletonList("2013-07-14T00:00:00.000Z/2013-11-16T00:00:00.000Z")));
         expectedQuery.put("granularity", "day");
         expectedQuery.put("aggregations", new JSONArray(Collections.singletonList(expectedAggregator)));
         expectedQuery.put("postAggregations", new JSONArray(Collections.singletonList(expectedPostAggregator)));

--- a/src/test/java/in/zapr/druid/druidry/query/aggregation/TopNQueryTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/aggregation/TopNQueryTest.java
@@ -33,6 +33,8 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.Collections;
 
+import in.zapr.druid.druidry.query.config.Context;
+import in.zapr.druid.druidry.query.config.Interval;
 import in.zapr.druid.druidry.aggregator.CountAggregator;
 import in.zapr.druid.druidry.aggregator.DoubleSumAggregator;
 import in.zapr.druid.druidry.aggregator.DruidAggregator;
@@ -51,8 +53,6 @@ import in.zapr.druid.druidry.postAggregator.ArithmeticPostAggregator;
 import in.zapr.druid.druidry.postAggregator.ConstantPostAggregator;
 import in.zapr.druid.druidry.postAggregator.DruidPostAggregator;
 import in.zapr.druid.druidry.postAggregator.FieldAccessPostAggregator;
-import in.zapr.druid.druidry.query.config.Context;
-import in.zapr.druid.druidry.query.config.Interval;
 import in.zapr.druid.druidry.topNMetric.SimpleMetric;
 import in.zapr.druid.druidry.topNMetric.TopNMetric;
 
@@ -72,29 +72,20 @@ public class TopNQueryTest {
 
         AndFilter filter = new AndFilter(Arrays.asList(selectorFilter1, selectorFilter2));
 
-        DruidAggregator aggregator1 =
-            LongSumAggregator.builder()
-                .name("count")
-                .fieldName("count")
-                .build();
-
-        DruidAggregator aggregator2 =
-            DoubleSumAggregator.builder()
-                .name("some_metric")
-                .fieldName("some_metric")
-                .build();
+        DruidAggregator aggregator1 = new LongSumAggregator("count", "count");
+        DruidAggregator aggregator2 = new DoubleSumAggregator("some_metric", "some_metric");
 
         FieldAccessPostAggregator fieldAccessPostAggregator1
-            = new FieldAccessPostAggregator("some_metric", "some_metric");
+                = new FieldAccessPostAggregator("some_metric", "some_metric");
 
         FieldAccessPostAggregator fieldAccessPostAggregator2
-            = new FieldAccessPostAggregator("count", "count");
+                = new FieldAccessPostAggregator("count", "count");
 
         DruidPostAggregator postAggregator = ArithmeticPostAggregator.builder()
-            .name("sample_divide")
-            .function(ArithmeticFunction.DIVIDE)
-            .fields(Arrays.asList(fieldAccessPostAggregator1, fieldAccessPostAggregator2))
-            .build();
+                .name("sample_divide")
+                .function(ArithmeticFunction.DIVIDE)
+                .fields(Arrays.asList(fieldAccessPostAggregator1, fieldAccessPostAggregator2))
+                .build();
 
         DateTime startTime = new DateTime(2013, 8, 31, 0, 0, 0, DateTimeZone.UTC);
         DateTime endTime = new DateTime(2013, 9, 3, 0, 0, 0, DateTimeZone.UTC);
@@ -106,77 +97,77 @@ public class TopNQueryTest {
         TopNMetric metric = new SimpleMetric("count");
 
         DruidTopNQuery query = DruidTopNQuery.builder()
-            .dataSource(new TableDataSource("sample_data"))
-            .dimension(dimension)
-            .threshold(5)
-            .topNMetric(metric)
-            .granularity(granularity)
-            .filter(filter)
-            .aggregators(Arrays.asList(aggregator1, aggregator2))
-            .postAggregators(Collections.singletonList(postAggregator))
-            .intervals(Collections.singletonList(interval))
-            .build();
+                .dataSource(new TableDataSource("sample_data"))
+                .dimension(dimension)
+                .threshold(5)
+                .topNMetric(metric)
+                .granularity(granularity)
+                .filter(filter)
+                .aggregators(Arrays.asList(aggregator1, aggregator2))
+                .postAggregators(Collections.singletonList(postAggregator))
+                .intervals(Collections.singletonList(interval))
+                .build();
 
         String expectedJsonAsString = "{\n" +
-            "  \"queryType\": \"topN\",\n" +
-            "  \"dataSource\": {\n" +
-            "    \"type\": \"table\",\n" +
-            "    \"name\": \"sample_data\"\n" +
-            "  },\n" +
-            "  \"dimension\": \"sample_dim\",\n" +
-            "  \"threshold\": 5,\n" +
-            "  \"metric\": \"count\",\n" +
-            "  \"granularity\": \"all\",\n" +
-            "  \"filter\": {\n" +
-            "    \"type\": \"and\",\n" +
-            "    \"fields\": [\n" +
-            "      {\n" +
-            "        \"type\": \"selector\",\n" +
-            "        \"dimension\": \"dim1\",\n" +
-            "        \"value\": \"some_value\"\n" +
-            "      },\n" +
-            "      {\n" +
-            "        \"type\": \"selector\",\n" +
-            "        \"dimension\": \"dim2\",\n" +
-            "        \"value\": \"some_other_val\"\n" +
-            "      }\n" +
-            "    ]\n" +
-            "  },\n" +
-            "  \"aggregations\": [\n" +
-            "    {\n" +
-            "      \"type\": \"longSum\",\n" +
-            "      \"name\": \"count\",\n" +
-            "      \"fieldName\": \"count\"\n" +
-            "    },\n" +
-            "    {\n" +
-            "      \"type\": \"doubleSum\",\n" +
-            "      \"name\": \"some_metric\",\n" +
-            "      \"fieldName\": \"some_metric\"\n" +
-            "    }\n" +
-            "  ],\n" +
-            "  \"postAggregations\": [\n" +
-            "    {\n" +
-            "      \"type\": \"arithmetic\",\n" +
-            "      \"name\": \"sample_divide\",\n" +
-            "      \"fn\": \"/\",\n" +
-            "      \"fields\": [\n" +
-            "        {\n" +
-            "          \"type\": \"fieldAccess\",\n" +
-            "          \"name\": \"some_metric\",\n" +
-            "          \"fieldName\": \"some_metric\"\n" +
-            "        },\n" +
-            "        {\n" +
-            "          \"type\": \"fieldAccess\",\n" +
-            "          \"name\": \"count\",\n" +
-            "          \"fieldName\": \"count\"\n" +
-            "        }\n" +
-            "      ]\n" +
-            "    }\n" +
-            "  ],\n" +
-            "  \"intervals\": [\n" +
-            "    \"2013-08-31T00:00:00.000Z/2013-09-03T00:00:00.000Z\"\n" +
-            "  ]\n" +
-            "}";
+                "  \"queryType\": \"topN\",\n" +
+                "  \"dataSource\": {\n" +
+                "    \"type\": \"table\",\n" +
+                "    \"name\": \"sample_data\"\n" +
+                "  },\n" +
+                "  \"dimension\": \"sample_dim\",\n" +
+                "  \"threshold\": 5,\n" +
+                "  \"metric\": \"count\",\n" +
+                "  \"granularity\": \"all\",\n" +
+                "  \"filter\": {\n" +
+                "    \"type\": \"and\",\n" +
+                "    \"fields\": [\n" +
+                "      {\n" +
+                "        \"type\": \"selector\",\n" +
+                "        \"dimension\": \"dim1\",\n" +
+                "        \"value\": \"some_value\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"type\": \"selector\",\n" +
+                "        \"dimension\": \"dim2\",\n" +
+                "        \"value\": \"some_other_val\"\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  },\n" +
+                "  \"aggregations\": [\n" +
+                "    {\n" +
+                "      \"type\": \"longSum\",\n" +
+                "      \"name\": \"count\",\n" +
+                "      \"fieldName\": \"count\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"type\": \"doubleSum\",\n" +
+                "      \"name\": \"some_metric\",\n" +
+                "      \"fieldName\": \"some_metric\"\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"postAggregations\": [\n" +
+                "    {\n" +
+                "      \"type\": \"arithmetic\",\n" +
+                "      \"name\": \"sample_divide\",\n" +
+                "      \"fn\": \"/\",\n" +
+                "      \"fields\": [\n" +
+                "        {\n" +
+                "          \"type\": \"fieldAccess\",\n" +
+                "          \"name\": \"some_metric\",\n" +
+                "          \"fieldName\": \"some_metric\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"type\": \"fieldAccess\",\n" +
+                "          \"name\": \"count\",\n" +
+                "          \"fieldName\": \"count\"\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"intervals\": [\n" +
+                "    \"2013-08-31T00:00:00.000Z/2013-09-03T00:00:00.000Z\"\n" +
+                "  ]\n" +
+                "}";
 
         String actualJson = objectMapper.writeValueAsString(query);
         JSONAssert.assertEquals(expectedJsonAsString, actualJson, JSONCompareMode.NON_EXTENSIBLE);
@@ -195,13 +186,13 @@ public class TopNQueryTest {
         Granularity granularity = new SimpleGranularity(PredefinedGranularity.DAY);
 
         DruidTopNQuery query = DruidTopNQuery.builder()
-            .dataSource(new TableDataSource("sample_data"))
-            .intervals(Collections.singletonList(interval))
-            .granularity(granularity)
-            .dimension(dimension)
-            .threshold(7)
-            .topNMetric(metric)
-            .build();
+                .dataSource(new TableDataSource("sample_data"))
+                .intervals(Collections.singletonList(interval))
+                .granularity(granularity)
+                .dimension(dimension)
+                .threshold(7)
+                .topNMetric(metric)
+                .build();
 
         String actualJson = objectMapper.writeValueAsString(query);
 
@@ -238,21 +229,21 @@ public class TopNQueryTest {
         DruidAggregator aggregator = new CountAggregator("Chill");
         DruidPostAggregator postAggregator = new ConstantPostAggregator("Keep", 16.11);
         Context context = Context.builder()
-            .populateCache(true)
-            .build();
+                .populateCache(true)
+                .build();
 
         DruidTopNQuery query = DruidTopNQuery.builder()
-            .dataSource(new TableDataSource("sample_data"))
-            .intervals(Collections.singletonList(interval))
-            .granularity(granularity)
-            .filter(filter)
-            .aggregators(Collections.singletonList(aggregator))
-            .postAggregators(Collections.singletonList(postAggregator))
-            .dimension(dimension)
-            .threshold(7)
-            .topNMetric(metric)
-            .context(context)
-            .build();
+                .dataSource(new TableDataSource("sample_data"))
+                .intervals(Collections.singletonList(interval))
+                .granularity(granularity)
+                .filter(filter)
+                .aggregators(Collections.singletonList(aggregator))
+                .postAggregators(Collections.singletonList(postAggregator))
+                .dimension(dimension)
+                .threshold(7)
+                .topNMetric(metric)
+                .context(context)
+                .build();
 
         String actualJson = objectMapper.writeValueAsString(query);
 
@@ -310,34 +301,34 @@ public class TopNQueryTest {
         DruidAggregator aggregator = new CountAggregator("Chill");
         DruidPostAggregator postAggregator = new ConstantPostAggregator("Keep", 16.11);
         Context context = Context.builder()
-            .populateCache(true)
-            .build();
+                .populateCache(true)
+                .build();
 
         DruidTopNQuery query1 = DruidTopNQuery.builder()
-            .dataSource(new TableDataSource("sample_data"))
-            .intervals(Collections.singletonList(interval))
-            .granularity(granularity)
-            .filter(filter)
-            .aggregators(Collections.singletonList(aggregator))
-            .postAggregators(Collections.singletonList(postAggregator))
-            .dimension(dimension)
-            .threshold(7)
-            .topNMetric(metric)
-            .context(context)
-            .build();
+                .dataSource(new TableDataSource("sample_data"))
+                .intervals(Collections.singletonList(interval))
+                .granularity(granularity)
+                .filter(filter)
+                .aggregators(Collections.singletonList(aggregator))
+                .postAggregators(Collections.singletonList(postAggregator))
+                .dimension(dimension)
+                .threshold(7)
+                .topNMetric(metric)
+                .context(context)
+                .build();
 
         DruidTopNQuery query2 = DruidTopNQuery.builder()
-            .dataSource(new TableDataSource("sample_data"))
-            .intervals(Collections.singletonList(interval))
-            .granularity(granularity)
-            .filter(filter)
-            .aggregators(Collections.singletonList(aggregator))
-            .postAggregators(Collections.singletonList(postAggregator))
-            .dimension(dimension)
-            .threshold(7)
-            .topNMetric(metric)
-            .context(context)
-            .build();
+                .dataSource(new TableDataSource("sample_data"))
+                .intervals(Collections.singletonList(interval))
+                .granularity(granularity)
+                .filter(filter)
+                .aggregators(Collections.singletonList(aggregator))
+                .postAggregators(Collections.singletonList(postAggregator))
+                .dimension(dimension)
+                .threshold(7)
+                .topNMetric(metric)
+                .context(context)
+                .build();
 
         Assert.assertEquals(query1, query2);
     }
@@ -357,34 +348,34 @@ public class TopNQueryTest {
         DruidAggregator aggregator = new CountAggregator("Chill");
         DruidPostAggregator postAggregator = new ConstantPostAggregator("Keep", 16.11);
         Context context = Context.builder()
-            .populateCache(true)
-            .build();
+                .populateCache(true)
+                .build();
 
         DruidTopNQuery query1 = DruidTopNQuery.builder()
-            .dataSource(new TableDataSource("sample_data"))
-            .intervals(Collections.singletonList(interval))
-            .granularity(granularity)
-            .filter(filter)
-            .aggregators(Collections.singletonList(aggregator))
-            .postAggregators(Collections.singletonList(postAggregator))
-            .dimension(dimension)
-            .threshold(7)
-            .topNMetric(metric)
-            .context(context)
-            .build();
+                .dataSource(new TableDataSource("sample_data"))
+                .intervals(Collections.singletonList(interval))
+                .granularity(granularity)
+                .filter(filter)
+                .aggregators(Collections.singletonList(aggregator))
+                .postAggregators(Collections.singletonList(postAggregator))
+                .dimension(dimension)
+                .threshold(7)
+                .topNMetric(metric)
+                .context(context)
+                .build();
 
         DruidTopNQuery query2 = DruidTopNQuery.builder()
-            .dataSource(new TableDataSource("sample_data"))
-            .intervals(Collections.singletonList(interval))
-            .granularity(granularity)
-            .filter(filter)
-            .aggregators(Collections.singletonList(aggregator))
-            .postAggregators(Collections.singletonList(postAggregator))
-            .dimension(dimension)
-            .threshold(314)
-            .topNMetric(metric)
-            .context(context)
-            .build();
+                .dataSource(new TableDataSource("sample_data"))
+                .intervals(Collections.singletonList(interval))
+                .granularity(granularity)
+                .filter(filter)
+                .aggregators(Collections.singletonList(aggregator))
+                .postAggregators(Collections.singletonList(postAggregator))
+                .dimension(dimension)
+                .threshold(314)
+                .topNMetric(metric)
+                .context(context)
+                .build();
 
         Assert.assertNotEquals(query1, query2);
     }
@@ -404,20 +395,20 @@ public class TopNQueryTest {
         DruidAggregator aggregator = new CountAggregator("Chill");
         DruidPostAggregator postAggregator = new ConstantPostAggregator("Keep", 16.11);
         Context context = Context.builder()
-            .populateCache(true)
-            .build();
+                .populateCache(true)
+                .build();
 
         DruidTopNQuery query1 = DruidTopNQuery.builder()
-            .dataSource(new TableDataSource("sample_data"))
-            .intervals(Collections.singletonList(interval))
-            .granularity(granularity)
-            .filter(filter)
-            .aggregators(Collections.singletonList(aggregator))
-            .postAggregators(Collections.singletonList(postAggregator))
-            .dimension(dimension)
-            .threshold(-5)
-            .topNMetric(metric)
-            .context(context)
-            .build();
+                .dataSource(new TableDataSource("sample_data"))
+                .intervals(Collections.singletonList(interval))
+                .granularity(granularity)
+                .filter(filter)
+                .aggregators(Collections.singletonList(aggregator))
+                .postAggregators(Collections.singletonList(postAggregator))
+                .dimension(dimension)
+                .threshold(-5)
+                .topNMetric(metric)
+                .context(context)
+                .build();
     }
 }

--- a/src/test/java/in/zapr/druid/druidry/query/aggregation/TopNQueryTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/aggregation/TopNQueryTest.java
@@ -137,12 +137,14 @@ public class TopNQueryTest {
                 "    {\n" +
                 "      \"type\": \"longSum\",\n" +
                 "      \"name\": \"count\",\n" +
-                "      \"fieldName\": \"count\"\n" +
+                "      \"fieldName\": \"count\",\n" +
+                "      \"expression\": null\n" +
                 "    },\n" +
                 "    {\n" +
                 "      \"type\": \"doubleSum\",\n" +
                 "      \"name\": \"some_metric\",\n" +
-                "      \"fieldName\": \"some_metric\"\n" +
+                "      \"fieldName\": \"some_metric\",\n" +
+                "      \"expression\": null\n" +
                 "    }\n" +
                 "  ],\n" +
                 "  \"postAggregations\": [\n" +
@@ -170,7 +172,7 @@ public class TopNQueryTest {
                 "}";
 
         String actualJson = objectMapper.writeValueAsString(query);
-        JSONAssert.assertEquals(actualJson, expectedJsonAsString, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(expectedJsonAsString, actualJson, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test


### PR DESCRIPTION
```
SELECT AVG(sum_sessionDurationInMs / "count")
FROM events
WHERE __time >= '2020-02-27' and __time < '2020-02-28'
```

When above query is translated to native JSON query, it converts `sum_sessionDurationInMs / "count"` into an expression and sets it into an aggregator:

```
{
  "queryType": "timeseries",
  "dataSource": {
    "type": "table",
    "name": "events"
  },
  "intervals": {
    "type": "intervals",
    "intervals": [
      "2020-02-27T00:00:00.000Z/2020-02-28T00:00:00.000Z"
    ]
  },
  "descending": false,
  "virtualColumns": [],
  "filter": null,
  "granularity": {
    "type": "all"
  },
  "aggregations": [
    {
      "type": "longSum",
      "name": "a0:sum",
      "fieldName": null,
      "expression": "(\"sum_sessionDurationInMs\" / \"count\")"
    },
    {
      "type": "count",
      "name": "a0:count"
    }
  ],
  "postAggregations": [
    {
      "type": "arithmetic",
      "name": "a0",
      "fn": "quotient",
      "fields": [
        {
          "type": "fieldAccess",
          "name": null,
          "fieldName": "a0:sum"
        },
        {
          "type": "fieldAccess",
          "name": null,
          "fieldName": "a0:count"
        }
      ],
      "ordering": null
    }
  ],
  "limit": 2147483647,
  "context": {
    "skipEmptyBuckets": true,
    "sqlOuterLimit": 100,
    "sqlQueryId": "5f8a13ff-1863-44fd-a2d1-8d96172cfae6"
  }
}
```