### PR TITLE
Missing topNmetric spec implementation

### DIFF
--- a/src/main/java/in/zapr/druid/druidry/topNMetric/DimensionMetric.java
+++ b/src/main/java/in/zapr/druid/druidry/topNMetric/DimensionMetric.java
@@ -16,21 +16,29 @@
 
 package in.zapr.druid.druidry.topNMetric;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import in.zapr.druid.druidry.query.config.SortingOrder;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NonNull;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
-public class InvertedMetric extends TopNMetric {
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DimensionMetric extends TopNMetric {
 
-    private static final String INVERTED_METRIC_TYPE = "inverted";
+    private static final String DIMENSION_METRIC_TYPE = "dimension";
 
     private String type;
-    private TopNMetric metric;
+    private SortingOrder ordering;
+    private String previousStop;
 
-    public InvertedMetric(@NonNull TopNMetric topNMetric) {
-        this.type = INVERTED_METRIC_TYPE;
-        this.metric = topNMetric;
+    @Builder
+    private DimensionMetric(SortingOrder ordering, String previousStop) {
+        this.type = DIMENSION_METRIC_TYPE;
+        this.ordering = ordering;
+        this.previousStop = previousStop;
     }
+
 }

--- a/src/main/java/in/zapr/druid/druidry/topNMetric/NumericMetric.java
+++ b/src/main/java/in/zapr/druid/druidry/topNMetric/NumericMetric.java
@@ -22,15 +22,16 @@ import lombok.NonNull;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
-public class InvertedMetric extends TopNMetric {
+public class NumericMetric extends TopNMetric {
 
-    private static final String INVERTED_METRIC_TYPE = "inverted";
+    private static final String NUMERIC_METRIC_TYPE = "numeric";
 
     private String type;
     private TopNMetric metric;
 
-    public InvertedMetric(@NonNull TopNMetric topNMetric) {
-        this.type = INVERTED_METRIC_TYPE;
+    public NumericMetric(@NonNull TopNMetric topNMetric) {
+        this.type = NUMERIC_METRIC_TYPE;
         this.metric = topNMetric;
     }
+
 }

--- a/src/main/java/in/zapr/druid/druidry/topNMetric/NumericMetric.java
+++ b/src/main/java/in/zapr/druid/druidry/topNMetric/NumericMetric.java
@@ -27,11 +27,11 @@ public class NumericMetric extends TopNMetric {
     private static final String NUMERIC_METRIC_TYPE = "numeric";
 
     private String type;
-    private TopNMetric metric;
+    private String metric;
 
-    public NumericMetric(@NonNull TopNMetric topNMetric) {
+    public NumericMetric(@NonNull String metric) {
         this.type = NUMERIC_METRIC_TYPE;
-        this.metric = topNMetric;
+        this.metric = metric;
     }
 
 }

--- a/src/test/java/in/zapr/druid/druidry/topNMetric/DimensionMetricTest.java
+++ b/src/test/java/in/zapr/druid/druidry/topNMetric/DimensionMetricTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018-present Red Brick Lane Marketing Solutions Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package in.zapr.druid.druidry.topNMetric;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import in.zapr.druid.druidry.query.config.SortingOrder;
+
+public class DimensionMetricTest {
+
+    private static ObjectMapper objectMapper;
+
+    @BeforeClass
+    public void init() {
+        objectMapper = new ObjectMapper();
+    }
+
+    private JSONObject getDimensionMetricJSON() throws JSONException {
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("type", "dimension");
+        return jsonObject;
+    }
+
+    @Test
+    public void testAllFields() throws JsonProcessingException, JSONException {
+
+        DimensionMetric dimensionMetric = DimensionMetric.builder()
+                .ordering(SortingOrder.LEXICOGRAPHIC)
+                .previousStop("x")
+                .build();
+
+        JSONObject jsonObject = getDimensionMetricJSON();
+        jsonObject.put("ordering", "lexicographic");
+        jsonObject.put("previousStop", "x");
+
+        String actualJSON = objectMapper.writeValueAsString(dimensionMetric);
+        String expectedJSON = jsonObject.toString();
+        JSONAssert.assertEquals(expectedJSON, actualJSON, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    public void testRequiredFields() throws JsonProcessingException, JSONException {
+
+        DimensionMetric dimensionMetric = DimensionMetric.builder()
+                .build();
+
+        JSONObject jsonObject = getDimensionMetricJSON();
+
+        String actualJSON = objectMapper.writeValueAsString(dimensionMetric);
+        String expectedJSON = jsonObject.toString();
+        JSONAssert.assertEquals(expectedJSON, actualJSON, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    public void testEqualsPositive() {
+        DimensionMetric dimensionMetric1 = DimensionMetric.builder()
+                .ordering(SortingOrder.STRLEN)
+                .build();
+        DimensionMetric dimensionMetric2 = DimensionMetric.builder()
+                .ordering(SortingOrder.STRLEN)
+                .build();
+
+        Assert.assertEquals(dimensionMetric1, dimensionMetric2);
+    }
+
+    @Test
+    public void testEqualsNegative() {
+        DimensionMetric dimensionMetric1 = DimensionMetric.builder()
+                .ordering(SortingOrder.STRLEN)
+                .build();
+        DimensionMetric dimensionMetric2 = DimensionMetric.builder()
+                .ordering(SortingOrder.ALPHANUMERIC)
+                .build();
+
+        Assert.assertNotEquals(dimensionMetric1, dimensionMetric2);
+    }
+}

--- a/src/test/java/in/zapr/druid/druidry/topNMetric/InvertedMetricTest.java
+++ b/src/test/java/in/zapr/druid/druidry/topNMetric/InvertedMetricTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.testng.Assert;
@@ -19,21 +20,35 @@ public class InvertedMetricTest {
         objectMapper = new ObjectMapper();
     }
 
+    private JSONObject getInvertedMetricJSON() throws JSONException {
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("type", "inverted");
+        jsonObject.put("metric", "count");
+        return jsonObject;
+    }
+
     @Test
     public void testAllFields() throws JsonProcessingException, JSONException {
+
         InvertedMetric invertedMetric = new InvertedMetric(new SimpleMetric("count"));
+
+        JSONObject jsonObject = getInvertedMetricJSON();
+
         String actualJSON = objectMapper.writeValueAsString(invertedMetric);
-        String expectedJson = "{\"metric\":\"count\",\"type\":\"inverted\"}";
-        JSONAssert.assertEquals(expectedJson, actualJSON, JSONCompareMode.NON_EXTENSIBLE);
+        String expectedJSON = jsonObject.toString();
+        JSONAssert.assertEquals(expectedJSON, actualJSON, JSONCompareMode.NON_EXTENSIBLE);;
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void testMetricMissingFields() {
-        new InvertedMetric(null);
+
+        InvertedMetric invertedMetric = new InvertedMetric(null);
     }
 
     @Test
     public void testEqualsPositive() {
+
         InvertedMetric invertedMetric1 = new InvertedMetric(new SimpleMetric("count"));
         InvertedMetric invertedMetric2 = new InvertedMetric(new SimpleMetric("count"));
 
@@ -42,6 +57,7 @@ public class InvertedMetricTest {
 
     @Test
     public void testEqualsNegative() {
+
         InvertedMetric invertedMetric1 = new InvertedMetric(new SimpleMetric("sum"));
         InvertedMetric invertedMetric2 = new InvertedMetric(new SimpleMetric("count"));
 

--- a/src/test/java/in/zapr/druid/druidry/topNMetric/NumericMetricTest.java
+++ b/src/test/java/in/zapr/druid/druidry/topNMetric/NumericMetricTest.java
@@ -47,7 +47,7 @@ public class NumericMetricTest {
     @Test
     public void testAllFields() throws JsonProcessingException, JSONException {
 
-        NumericMetric numericMetric = new NumericMetric(new SimpleMetric("events"));
+        NumericMetric numericMetric = new NumericMetric("events");
 
         JSONObject jsonObject = getNumericMetricJSON();
 
@@ -65,8 +65,8 @@ public class NumericMetricTest {
     @Test
     public void testEqualsPositive() {
 
-        NumericMetric numericMetric1 =  new NumericMetric(new SimpleMetric("events"));
-        NumericMetric numericMetric2 =  new NumericMetric(new SimpleMetric("events"));
+        NumericMetric numericMetric1 = new NumericMetric("events");
+        NumericMetric numericMetric2 = new NumericMetric("events");
 
         Assert.assertEquals(numericMetric1, numericMetric2);
     }
@@ -74,8 +74,8 @@ public class NumericMetricTest {
     @Test
     public void testEqualsNegative() {
 
-        NumericMetric numericMetric1 =  new NumericMetric(new SimpleMetric("events1"));
-        NumericMetric numericMetric2 =  new NumericMetric(new SimpleMetric("events2"));
+        NumericMetric numericMetric1 = new NumericMetric("events1");
+        NumericMetric numericMetric2 = new NumericMetric("events2");
 
         Assert.assertNotEquals(numericMetric1, numericMetric2);
     }

--- a/src/test/java/in/zapr/druid/druidry/topNMetric/NumericMetricTest.java
+++ b/src/test/java/in/zapr/druid/druidry/topNMetric/NumericMetricTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018-present Red Brick Lane Marketing Solutions Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package in.zapr.druid.druidry.topNMetric;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class NumericMetricTest {
+
+    private static ObjectMapper objectMapper;
+
+    @BeforeClass
+    public void init() {
+        objectMapper = new ObjectMapper();
+    }
+
+    private JSONObject getNumericMetricJSON() throws JSONException {
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("type", "numeric");
+        jsonObject.put("metric", "events");
+        return jsonObject;
+    }
+
+    @Test
+    public void testAllFields() throws JsonProcessingException, JSONException {
+
+        NumericMetric numericMetric = new NumericMetric(new SimpleMetric("events"));
+
+        JSONObject jsonObject = getNumericMetricJSON();
+
+        String actualJSON = objectMapper.writeValueAsString(numericMetric);
+        String expectedJSON = jsonObject.toString();
+        JSONAssert.assertEquals(expectedJSON, actualJSON, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullField1() {
+
+        NumericMetric numericMetric = new NumericMetric(null);
+    }
+
+    @Test
+    public void testEqualsPositive() {
+
+        NumericMetric numericMetric1 =  new NumericMetric(new SimpleMetric("events"));
+        NumericMetric numericMetric2 =  new NumericMetric(new SimpleMetric("events"));
+
+        Assert.assertEquals(numericMetric1, numericMetric2);
+    }
+
+    @Test
+    public void testEqualsNegative() {
+
+        NumericMetric numericMetric1 =  new NumericMetric(new SimpleMetric("events1"));
+        NumericMetric numericMetric2 =  new NumericMetric(new SimpleMetric("events2"));
+
+        Assert.assertNotEquals(numericMetric1, numericMetric2);
+    }
+}

--- a/src/test/java/in/zapr/druid/druidry/topNMetric/NumericMetricTest.java
+++ b/src/test/java/in/zapr/druid/druidry/topNMetric/NumericMetricTest.java
@@ -57,7 +57,7 @@ public class NumericMetricTest {
     }
 
     @Test(expectedExceptions = NullPointerException.class)
-    public void testNullField1() {
+    public void testNullField() {
 
         NumericMetric numericMetric = new NumericMetric(null);
     }


### PR DESCRIPTION
Implemented `numeric` & `dimension` metrics of topNmetric and refactoring in `inverted` metric.

Druid-doc : https://druid.apache.org/docs/latest/querying/topnmetricspec.html