### PR TITLE
158 - add support for basic auth

### DIFF
--- a/src/main/java/in/zapr/druid/druidry/client/DruidConfiguration.java
+++ b/src/main/java/in/zapr/druid/druidry/client/DruidConfiguration.java
@@ -56,12 +56,18 @@ public class DruidConfiguration {
      */
     private Integer concurrentConnectionsRequired;
 
+    /**
+     * (optional) Credentials for HTTP basic authorization if needed
+     */
+    private HttpBasicAuth httpBasicAuth;
+
     @Builder
     private DruidConfiguration(DruidQueryProtocol protocol,
                                String host,
                                Integer port,
                                String endpoint,
-                               Integer concurrentConnectionsRequired) {
+                               Integer concurrentConnectionsRequired,
+                               HttpBasicAuth httpBasicAuth) {
 
         if (StringUtils.isEmpty(host)) {
             throw new IllegalArgumentException("Host cannot be null or empty");
@@ -88,6 +94,7 @@ public class DruidConfiguration {
         this.port = port;
         this.endpoint = endpoint;
         this.concurrentConnectionsRequired = concurrentConnectionsRequired;
+        this.httpBasicAuth = httpBasicAuth;
     }
 
     protected String getUrl() {

--- a/src/main/java/in/zapr/druid/druidry/client/DruidJerseyClient.java
+++ b/src/main/java/in/zapr/druid/druidry/client/DruidJerseyClient.java
@@ -22,7 +22,6 @@ import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.glassfish.jersey.apache.connector.ApacheClientProperties;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
-import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 
 import java.util.List;
 
@@ -51,15 +50,6 @@ public class DruidJerseyClient implements DruidClient {
     private Client client;
     private WebTarget queryWebTarget;
 
-    private String username;
-    private String password;
-
-
-    public DruidJerseyClient(@NonNull DruidConfiguration druidConfiguration, String username, String password) {
-        this(druidConfiguration);
-        this.username = username;
-        this.password = password;
-    }
 
     public DruidJerseyClient(@NonNull DruidConfiguration druidConfiguration) {
         this(druidConfiguration, null);
@@ -88,13 +78,9 @@ public class DruidJerseyClient implements DruidClient {
 
             this.client = ClientBuilder.newClient(this.jerseyConfig);
 
-            if (this.username != null && this.password != null) {
-                HttpAuthenticationFeature authFeature = HttpAuthenticationFeature
-                        .basicBuilder()
-                        .credentials(this.username, this.password)
-                        .build();
-
-                this.client.register(authFeature);
+            HttpBasicAuth basicAuth = this.druidConfiguration.getHttpBasicAuth();
+            if (basicAuth != null) {
+                this.client.register(basicAuth.getAuthFeature());
             }
 
             this.queryWebTarget = this.client.target(this.druidUrl);

--- a/src/main/java/in/zapr/druid/druidry/client/DruidJerseyClient.java
+++ b/src/main/java/in/zapr/druid/druidry/client/DruidJerseyClient.java
@@ -22,6 +22,7 @@ import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.glassfish.jersey.apache.connector.ApacheClientProperties;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 
 import java.util.List;
 
@@ -50,13 +51,22 @@ public class DruidJerseyClient implements DruidClient {
     private Client client;
     private WebTarget queryWebTarget;
 
+    private String username;
+    private String password;
+
+
+    public DruidJerseyClient(@NonNull DruidConfiguration druidConfiguration, String username, String password) {
+        this(druidConfiguration);
+        this.username = username;
+        this.password = password;
+    }
+
     public DruidJerseyClient(@NonNull DruidConfiguration druidConfiguration) {
         this(druidConfiguration, null);
     }
 
     public DruidJerseyClient(@NonNull DruidConfiguration druidConfiguration,
                              ClientConfig jerseyConfig) {
-
         this.druidUrl = druidConfiguration.getUrl();
         this.jerseyConfig = jerseyConfig;
 
@@ -77,6 +87,16 @@ public class DruidJerseyClient implements DruidClient {
             }
 
             this.client = ClientBuilder.newClient(this.jerseyConfig);
+
+            if (this.username != null && this.password != null) {
+                HttpAuthenticationFeature authFeature = HttpAuthenticationFeature
+                        .basicBuilder()
+                        .credentials(this.username, this.password)
+                        .build();
+
+                this.client.register(authFeature);
+            }
+
             this.queryWebTarget = this.client.target(this.druidUrl);
 
         } catch (Exception e) {

--- a/src/main/java/in/zapr/druid/druidry/client/HttpBasicAuth.java
+++ b/src/main/java/in/zapr/druid/druidry/client/HttpBasicAuth.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018-present Red Brick Lane Marketing Solutions Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package in.zapr.druid.druidry.client;
+
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+
+
+@RequiredArgsConstructor
+public class HttpBasicAuth {
+
+    @NonNull
+    private final String username;
+
+    @NonNull
+    private final String password;
+
+    HttpAuthenticationFeature getAuthFeature() {
+        return HttpAuthenticationFeature
+                .basicBuilder()
+                .credentials(username, password)
+                .build();
+    }
+}

--- a/src/test/java/in/zapr/druid/druidry/client/DruidConfigurationTest.java
+++ b/src/test/java/in/zapr/druid/druidry/client/DruidConfigurationTest.java
@@ -23,6 +23,8 @@ public class DruidConfigurationTest {
 
     @Test
     public void testDruidConfiguration() {
+        HttpBasicAuth httpBasicAuth = new HttpBasicAuth("someuser", "secret");
+
         DruidConfiguration config = DruidConfiguration
                 .builder()
                 .protocol(DruidQueryProtocol.HTTPS)
@@ -30,6 +32,7 @@ public class DruidConfigurationTest {
                 .port(443)
                 .endpoint("druid/v2/")
                 .concurrentConnectionsRequired(8)
+                .httpBasicAuth(httpBasicAuth)
                 .build();
 
         Assert.assertEquals(config.getProtocol(), DruidQueryProtocol.HTTPS);
@@ -37,6 +40,7 @@ public class DruidConfigurationTest {
         Assert.assertEquals(config.getPort().intValue(), 443);
         Assert.assertEquals(config.getEndpoint(), "druid/v2/");
         Assert.assertEquals(config.getConcurrentConnectionsRequired().intValue(), 8);
+        Assert.assertEquals(config.getHttpBasicAuth(), httpBasicAuth);
         Assert.assertEquals(config.getUrl(), "https://druid.zapr.in:443/druid/v2/");
     }
 
@@ -52,6 +56,7 @@ public class DruidConfigurationTest {
         Assert.assertEquals(config.getProtocol(), DruidQueryProtocol.HTTP);
         Assert.assertEquals(config.getPort().intValue(), 8082);
         Assert.assertEquals(config.getUrl(), "http://druid.zapr.in:8082/druid/v2/");
+        Assert.assertNull(config.getHttpBasicAuth());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/src/test/java/in/zapr/druid/druidry/client/HttpBasicAuthTest.java
+++ b/src/test/java/in/zapr/druid/druidry/client/HttpBasicAuthTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018-present Red Brick Lane Marketing Solutions Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package in.zapr.druid.druidry.client;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+
+public class HttpBasicAuthTest {
+
+    @Test
+    public void testHttpBasicAuthWithCredentials() {
+        HttpBasicAuth httpBasicAuth = new HttpBasicAuth("user", "secret");
+
+        Assert.assertTrue(
+            httpBasicAuth.getAuthFeature().toString()
+                .startsWith("org.glassfish.jersey.client.authentication.HttpAuthenticationFeature")
+        );
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testHttpBasicAuthWithoutCredentials() {
+        new HttpBasicAuth(null, null);
+    }
+
+}


### PR DESCRIPTION
With this change, it is possible to specify httpBasicAuth credentials in the DruidConfiguration so that they can be used to register the client in the DruidJerseyClient.

We make use of this in our local use of Druidry. Having this feature in the open source project will make it easier for us to maintain our usage of Druidry and also help others that need this feature.

See [#158](https://github.com/zapr-oss/druidry/issues/158) [#152](https://github.com/zapr-oss/druidry/issues/152).

Cc: @abhi-zapr  @scrohde