### PR TITLE
Add query context flag doAggregateTopNMetricFirst

### DIFF
--- a/src/main/java/in/zapr/druid/druidry/query/config/Context.java
+++ b/src/main/java/in/zapr/druid/druidry/query/config/Context.java
@@ -50,6 +50,7 @@ public class Context {
 
     // topN query contexts
     private Integer minTopNThreshold;
+    private Boolean doAggregateTopNMetricFirst;
 
     // timeseries query contexts
     private Boolean skipEmptyBuckets;
@@ -90,6 +91,7 @@ public class Context {
                     Boolean serializeDateTimeAsLong,
                     Boolean serializeDateTimeAsLongInner,
                     Integer minTopNThreshold,
+                    Boolean doAggregateTopNMetricFirst,
                     Boolean skipEmptyBuckets,
                     Long maxMergingDictionarySize,
                     Long maxOnDiskStorage,
@@ -124,6 +126,7 @@ public class Context {
         this.serializeDateTimeAsLong = serializeDateTimeAsLong;
         this.serializeDateTimeAsLongInner = serializeDateTimeAsLongInner;
         this.minTopNThreshold = minTopNThreshold;
+        this.doAggregateTopNMetricFirst = doAggregateTopNMetricFirst;
         this.skipEmptyBuckets = skipEmptyBuckets;
         this.maxMergingDictionarySize = maxMergingDictionarySize;
         this.maxOnDiskStorage = maxOnDiskStorage;

--- a/src/test/java/in/zapr/druid/druidry/query/config/ContextTest.java
+++ b/src/test/java/in/zapr/druid/druidry/query/config/ContextTest.java
@@ -83,6 +83,7 @@ public class ContextTest {
                 .useOffheap(false)
                 .vectorize(Vectorize.FORCE)
                 .vectorSize(1024)
+                .doAggregateTopNMetricFirst(true)
                 .build();
 
         JSONObject jsonObject = new JSONObject();
@@ -101,6 +102,7 @@ public class ContextTest {
         jsonObject.put("serializeDateTimeAsLong", true);
         jsonObject.put("serializeDateTimeAsLongInner", true);
         jsonObject.put("minTopNThreshold", 10);
+        jsonObject.put("doAggregateTopNMetricFirst", true);
         jsonObject.put("skipEmptyBuckets", true);
         jsonObject.put("maxMergingDictionarySize", 65536L);
         jsonObject.put("maxOnDiskStorage", 262144L);


### PR DESCRIPTION
This PR adds the `doAggregateTopNMetricFirst` flag to the query context to support for selecting a `TopNAlgorithm`. 

https://github.com/apache/druid/blob/master/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java#L140