### PR TITLE
add version sorting order

### DIFF
--- a/src/main/java/in/zapr/druid/druidry/query/config/SortingOrder.java
+++ b/src/main/java/in/zapr/druid/druidry/query/config/SortingOrder.java
@@ -22,7 +22,8 @@ public enum SortingOrder {
     LEXICOGRAPHIC("lexicographic"),
     ALPHANUMERIC("alphanumeric"),
     NUMERIC("numeric"),
-    STRLEN("strlen");
+    STRLEN("strlen"),
+    VERSION("version");
 
     private String value;
 


### PR DESCRIPTION
Druid supports version sorting order but druidry doesn't includes it.

https://druid.apache.org/docs/latest/querying/sorting-orders.html